### PR TITLE
Add script to upload Dolma dataset to S3

### DIFF
--- a/experiments/1_data_radar_and_acquisition/upload_dolmo_dataset_S3.sh
+++ b/experiments/1_data_radar_and_acquisition/upload_dolmo_dataset_S3.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+DOLMA_VERSION="v1_7"
+SAMPLE_COUNT=3
+
+WORKDIR="/mnt/dolma_tmp"
+mkdir -p "$WORKDIR"
+
+S3_BUCKET="s3://upload-dataset"
+S3_PREFIX="dolma_sample/${DOLMA_VERSION}/"
+
+# Install tools
+sudo dnf install -y git wget awscli
+
+# Clone repo
+git clone https://huggingface.co/datasets/allenai/dolma || true
+
+URL_FILE="dolma/urls/${DOLMA_VERSION}.txt"
+
+echo "Downloading first ${SAMPLE_COUNT} shards..."
+
+head -n ${SAMPLE_COUNT} "$URL_FILE" | while read -r url; do
+
+  filename=$(basename "$url")
+
+  echo "Downloading: $filename"
+
+  # Resume-enabled download
+  wget -c -P "$WORKDIR" "$url"
+
+  echo "Uploading to S3..."
+  aws s3 cp "$WORKDIR/$filename" \
+           "${S3_BUCKET}/${S3_PREFIX}${filename}"
+
+  echo "Deleting local file..."
+  rm -f "$WORKDIR/$filename"
+
+done
+
+echo "Sample test complete!"


### PR DESCRIPTION
[Task 193](https://github.com/The-School-of-AI/LLM/issues/193)
Script will
download one file in EC2
upload immediately to S2
delete local copy from EC2
Disk Usage Stays Minimal:

Even for multi-terabyte datasets, your EC2 disk only needs space for one shard at a time Example:
shard size: 5–20 GB
EC2 disk needed: ~50 GB safe buffer Not multi-TB.

✅ Cost Breakdown (What Actually Costs Money)

Downloading from Hugging Face → EC2
Cost: $0
Inbound traffic into AWS is free:
EC2 inbound = free
S3 inbound = free
So downloading does not cost AWS data transfer fees.

Uploading EC2 → S3 (same region)
Cost: $0
Traffic between EC2 and S3 in the same region is free or extremely low: No “internet egress”
No cross-region charge
So upload is not charged like outbound internet traffic.

Storage in S3
This is the real cost:
Example: Dolma ~10 TB
S3 Standard storage:
~$0.023 per GB/month
So:
10,000 GB × 0.023 ≈ $230/month
That dominates everything.

EC2 runtime cost
Also real cost:
If download takes 20 hours on c6i.large:
~$0.085/hour
20 × 0.085 ≈ $1.70
EC2 compute cost is tiny compared to storage.

# Pull Request Template

## Description

Please include a summary of the changes and the related issue. Highlight any key points that reviewers should focus on.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [ ] My code follows the style guidelines, gitflow branching strategy, and naming conventions of this project [Contribution Guidelines](<https://github.com/The-School-of-AI/LLM/tree/main/experiments/>

## Reviewers

- [ ] **Reviewer 1**: A member from your own team.
- [ ] **Reviewer 2**: A member from the repo owners team (@The-School-of-AI/llm-repo-owners).

> **Note**: Every pull request requires atleast 2 reviewers/approvers before it can be merged.
