### PR TITLE
240: Subset download and verification scripts for Dolma, Sangraha, and IndicCorpV2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,8 @@ cython_debug/
 logs/
 /data
 /outputs
+/out
+out/
 /logs
 
 *.pt 

--- a/experiments/1_data_radar_and_acquisition/240_dataset_subset_download_and_verify/README.md
+++ b/experiments/1_data_radar_and_acquisition/240_dataset_subset_download_and_verify/README.md
@@ -1,0 +1,51 @@
+# Dataset subset download and verification (Task #240)
+
+Lightweight, config-driven tooling for **preflight validation of large text datasets**
+before full ingestion or upload to S3.
+
+This module focuses on **downloading small subsets**, validating dataset configs/splits,
+and verifying that outputs are correctly formatted and parseable.
+
+> Note: This is **not a replacement** for the full dataset ingestion and S3 upload
+pipeline implemented under **Task #160**. It is intended as an upstream sanity-check
+step.
+
+---
+
+## Supported datasets
+
+- **Sangraha (AI4Bharat)**
+  - Config: `verified`
+  - Language splits (e.g. `hin`, `eng`)
+- **IndicCorpV2 (AI4Bharat)**
+  - Language-script splits (e.g. `hin_Deva`, `ben_Beng`)
+- **Dolma (AllenAI)**
+  - Optional shard-based download (disabled by default due to large shard sizes)
+
+---
+
+## What this does
+
+1. Downloads **small subsets** of datasets using streaming or shard URLs
+2. Writes outputs as **JSONL** under a local `out/` directory
+3. Generates a **manifest** with counts and schema hints
+4. Verifies:
+   - files exist
+   - record counts match expectations
+   - JSONL is parseable
+
+This enables early detection of:
+- incorrect dataset configs
+- invalid splits
+- schema or formatting issues
+- broken download paths
+
+---
+
+## How to run
+
+```bash
+cd experiments/1_data_radar_and_acquisition/240_dataset_subset_download_and_verify
+pip install -r requirements.txt
+python src/sample_download.py
+python src/sample_verify.py

--- a/experiments/1_data_radar_and_acquisition/240_dataset_subset_download_and_verify/configs/sample.toml
+++ b/experiments/1_data_radar_and_acquisition/240_dataset_subset_download_and_verify/configs/sample.toml
@@ -1,0 +1,27 @@
+[run]
+out_dir = "out"
+seed = 42
+
+[sample]
+# Dolma: number of shard files to download (0 = skip)
+dolma_shards = 3
+
+# Sangraha: records per language split
+sangraha_n = 1000
+# valid Sangraha splits for verified config are: hin, eng, tam, tel, etc.
+sangraha_langs = ["hin", "eng"]
+
+# IndicCorpV2: records per split (these are the dataset's available splits)
+indic_n = 2000
+indic_splits = ["hin_Deva", "ben_Beng"]
+
+[datasets.dolma]
+repo_id = "allenai/dolma"
+version = "v1_7"
+
+[datasets.sangraha]
+repo = "ai4bharat/sangraha"
+config = "verified"
+
+[datasets.indiccorp_v2]
+repo = "ai4bharat/IndicCorpV2"

--- a/experiments/1_data_radar_and_acquisition/240_dataset_subset_download_and_verify/requirements.txt
+++ b/experiments/1_data_radar_and_acquisition/240_dataset_subset_download_and_verify/requirements.txt
@@ -1,0 +1,4 @@
+datasets==2.19.0
+huggingface-hub>=0.23.0
+requests>=2.31.0
+tomlkit>=0.12.0

--- a/experiments/1_data_radar_and_acquisition/240_dataset_subset_download_and_verify/src/sample_download.py
+++ b/experiments/1_data_radar_and_acquisition/240_dataset_subset_download_and_verify/src/sample_download.py
@@ -1,0 +1,169 @@
+import json
+import random
+import time
+from itertools import islice
+from pathlib import Path
+
+import requests
+from datasets import load_dataset
+from huggingface_hub import hf_hub_download
+from tomlkit import parse
+
+CONFIG_PATH = Path("configs/sample.toml")
+
+
+def write_jsonl(path: Path, rows_iter):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    first_keys = []
+    with path.open("w", encoding="utf-8") as f:
+        for r in rows_iter:
+            if count == 0:
+                first_keys = list(r.keys())
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+            count += 1
+    return count, first_keys
+
+
+def stream_rows_to_jsonl(repo: str, name: str, split: str, n: int, out_path: Path):
+    ds = load_dataset(repo, name if name else None, split=split, streaming=True)
+    return write_jsonl(out_path, islice(iter(ds), n))
+
+
+def load_dolma_urls(repo_id: str, version: str):
+    url_file = hf_hub_download(
+        repo_id=repo_id,
+        repo_type="dataset",
+        filename=f"urls/{version}.txt",
+    )
+    urls = Path(url_file).read_text(encoding="utf-8").splitlines()
+    return [u.strip() for u in urls if u.strip()]
+
+
+def download_file(url: str, out_path: Path, timeout=1200):
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with requests.get(url, stream=True, timeout=timeout) as r:
+        r.raise_for_status()
+        with out_path.open("wb") as f:
+            for chunk in r.iter_content(chunk_size=1024 * 1024):
+                if chunk:
+                    f.write(chunk)
+
+
+def main():
+    cfg = parse(CONFIG_PATH.read_text(encoding="utf-8"))
+    out_root = Path(cfg["run"]["out_dir"]) / "raw"
+    seed = int(cfg["run"].get("seed", 42))
+    random.seed(seed)
+
+    manifest = {
+        "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "seed": seed,
+        "outputs": [],
+    }
+
+    # ---- Dolma: download first N shard files ----
+    dolma_cfg = cfg["datasets"]["dolma"]
+    dolma_repo = str(dolma_cfg["repo_id"])
+    dolma_ver = str(dolma_cfg["version"])
+    dolma_shards = int(cfg["sample"].get("dolma_shards", 0))
+
+    if dolma_shards > 0:
+        print(f"Sampling dolma (shards) | repo={dolma_repo} version={dolma_ver} shards={dolma_shards}")
+        urls = load_dolma_urls(dolma_repo, dolma_ver)
+        if len(urls) < dolma_shards:
+            raise RuntimeError(f"Requested {dolma_shards} shards but only found {len(urls)} urls")
+
+        dolma_dir = out_root / "dolma" / dolma_ver / "shards"
+        downloaded = []
+
+        for i, url in enumerate(urls[:dolma_shards]):
+            filename = url.split("/")[-1]
+            out_path = dolma_dir / filename
+
+            if out_path.exists() and out_path.stat().st_size > 0:
+                size = out_path.stat().st_size
+                print(f"  skipping (exists) {i+1}/{dolma_shards}: {filename} ({size} bytes)")
+                downloaded.append(
+                    {"url": url, "path": str(out_path), "bytes": size, "filename": filename, "skipped": True}
+                )
+                continue
+
+            print(f"  downloading shard {i+1}/{dolma_shards}: {filename}")
+            download_file(url, out_path)
+            size = out_path.stat().st_size
+            downloaded.append({"url": url, "path": str(out_path), "bytes": size, "filename": filename})
+            print(f"  saved {size} bytes -> {out_path}")
+
+        manifest["outputs"].append(
+            {
+                "dataset": "dolma",
+                "mode": "shards",
+                "repo_id": dolma_repo,
+                "version": dolma_ver,
+                "shards_requested": dolma_shards,
+                "shards_downloaded": downloaded,
+            }
+        )
+    else:
+        print("Skipping dolma (shards=0)")
+
+    # ---- Sangraha: streaming row sample ----
+    sang_cfg = cfg["datasets"]["sangraha"]
+    sang_repo = str(sang_cfg["repo"])
+    sang_config = str(sang_cfg.get("config", "verified"))
+    sang_n = int(cfg["sample"]["sangraha_n"])
+    langs = [str(x) for x in cfg["sample"]["sangraha_langs"]]
+
+    for lang in langs:
+        print(f"Sampling sangraha | repo={sang_repo} config={sang_config} split={lang} n={sang_n}")
+        out_path = out_root / "sangraha" / sang_config / lang / "sample.jsonl"
+        written_n, first_keys = stream_rows_to_jsonl(sang_repo, sang_config, lang, sang_n, out_path)
+
+        manifest["outputs"].append(
+            {
+                "dataset": "sangraha",
+                "mode": "rows",
+                "repo": sang_repo,
+                "config": sang_config,
+                "split": lang,
+                "requested_n": sang_n,
+                "written_n": written_n,
+                "path": str(out_path),
+                "first_keys": first_keys[:25],
+            }
+        )
+        print(f"  wrote {written_n} -> {out_path}")
+
+    # ---- IndicCorpV2: streaming row sample for multiple splits ----
+    ind_cfg = cfg["datasets"]["indiccorp_v2"]
+    ind_repo = str(ind_cfg["repo"])
+    ind_n = int(cfg["sample"]["indic_n"])
+    ind_splits = [str(x) for x in cfg["sample"]["indic_splits"]]
+
+    for sp in ind_splits:
+        print(f"Sampling indiccorp_v2 | repo={ind_repo} split={sp} n={ind_n}")
+        out_path = out_root / "indiccorp_v2" / sp.replace("/", "_") / "sample.jsonl"
+        written_n, first_keys = stream_rows_to_jsonl(ind_repo, "", sp, ind_n, out_path)
+
+        manifest["outputs"].append(
+            {
+                "dataset": "indiccorp_v2",
+                "mode": "rows",
+                "repo": ind_repo,
+                "split": sp,
+                "requested_n": ind_n,
+                "written_n": written_n,
+                "path": str(out_path),
+                "first_keys": first_keys[:25],
+            }
+        )
+        print(f"  wrote {written_n} -> {out_path}")
+
+    manifest_path = out_root.parent / "sample_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"\nWrote manifest: {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/1_data_radar_and_acquisition/240_dataset_subset_download_and_verify/src/sample_verify.py
+++ b/experiments/1_data_radar_and_acquisition/240_dataset_subset_download_and_verify/src/sample_verify.py
@@ -1,0 +1,118 @@
+import json
+from pathlib import Path
+
+from tomlkit import parse
+
+CONFIG_PATH = Path("configs/sample.toml")
+
+
+def read_jsonl(path: Path):
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                yield json.loads(line)
+
+
+def main():
+    cfg = parse(CONFIG_PATH.read_text(encoding="utf-8"))
+    out_root = Path(cfg["run"]["out_dir"])
+    manifest_path = out_root / "sample_manifest.json"
+
+    if not manifest_path.exists():
+        raise RuntimeError("out/sample_manifest.json not found. Run sample_download.py first.")
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    dolma_shards_cfg = int(cfg["sample"].get("dolma_shards", 0))
+    failures = 0
+
+    print("Verifying outputs based on manifest\n")
+
+    for o in manifest.get("outputs", []):
+        ds = o.get("dataset")
+        mode = o.get("mode")
+
+        # Dolma shard verification (only if configured)
+        if ds == "dolma" and mode == "shards":
+            if dolma_shards_cfg == 0:
+                # If manifest has dolma but config says 0, just ignore it.
+                print("SKIP: dolma present in manifest but dolma_shards=0 in config")
+                continue
+
+            shards = o.get("shards_downloaded", [])
+            requested = int(o.get("shards_requested", 0))
+
+            if requested != dolma_shards_cfg:
+                print(f"FAIL: dolma config mismatch (config={dolma_shards_cfg}, manifest={requested})")
+                failures += 1
+                continue
+
+            if len(shards) != requested:
+                print(f"FAIL: dolma shard count mismatch (expected={requested}, got={len(shards)})")
+                failures += 1
+                continue
+
+            ok = True
+            for s in shards:
+                p = Path(s["path"])
+                if not p.exists():
+                    print(f"FAIL: missing dolma shard file {p}")
+                    failures += 1
+                    ok = False
+                    continue
+                size = p.stat().st_size
+                if size <= 0:
+                    print(f"FAIL: empty dolma shard file {p}")
+                    failures += 1
+                    ok = False
+            if ok:
+                print(f"OK: dolma shards verified ({requested})")
+            continue
+
+        # Rows (JSONL) verification
+        p_str = o.get("path")
+        if not p_str:
+            print(f"FAIL: missing path in manifest entry: {o}")
+            failures += 1
+            continue
+
+        p = Path(p_str)
+        expected = int(o.get("written_n", -1))
+        label = f"{ds}"
+
+        # make label more informative
+        if ds == "sangraha":
+            label = f"sangraha/{o.get('config')}/{o.get('split')}"
+        elif ds == "indiccorp_v2":
+            label = f"indiccorp_v2/{o.get('split')}"
+
+        if not p.exists():
+            print(f"FAIL: missing file {label}: {p}")
+            failures += 1
+            continue
+
+        # parse + count
+        count = 0
+        try:
+            for _ in read_jsonl(p):
+                count += 1
+        except Exception as e:
+            print(f"FAIL: JSONL parse error {label}: {p} ({e})")
+            failures += 1
+            continue
+
+        if expected >= 0 and count != expected:
+            print(f"FAIL: count mismatch {label}: expected={expected} got={count}")
+            failures += 1
+        else:
+            print(f"OK: {label}: {count} records")
+
+    if failures:
+        raise RuntimeError(f"Verification failed with {failures} error(s).")
+
+    print("\nAll checks passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
This PR adds a lightweight, config-driven workflow to download and verify
small subsets of key pretraining datasets before running full downloads
or S3 uploads.

The goal is to validate:
- dataset configs and splits
- streaming access
- JSONL integrity
- expected record counts

## Datasets covered
- **Dolma** – shard-based subset download
- **Sangraha** – `verified` config with language splits
- **IndicCorpV2** – language–script splits

## What’s included
- `sample_download.py`: streaming-based subset downloader
- `sample_verify.py`: manifest-driven verification script
- `sample.toml`: dataset and sampling configuration
- Minimal README and requirements

## Related issues
- Closes **#240**
- Part of **#160** (Task: Uploading dataset script to AWS S3)

## Notes
- Intentionally limited to small samples (safe to run locally or on EC2)
- No S3 upload logic included (this is a validation step)
- Designed to be exploratory and composable with later pipelines
