### PR TITLE
Uv 308/support csv writes

### DIFF
--- a/experiments/2_curirculum_architects/OUTPUT_SCHEMA.md
+++ b/experiments/2_curirculum_architects/OUTPUT_SCHEMA.md
@@ -1,0 +1,80 @@
+# Curriculum Architects — Output Schema (CSV)
+
+Canonical schema for the **parsable flat output** and **rejected-files log** produced by the tagging pipeline.
+
+**Schema version:** `v1`
+
+---
+
+## 1. Main output CSV (parsable file)
+
+**File naming:** `{output_prefix}.csv` (e.g. `output.csv`, or same base name as Parquet with `.csv`).
+
+| Column | Type | Required | Description |
+|--------|------|----------|-------------|
+| `uuid` | string (UUID) | yes | Unique per row (e.g. UUID4). |
+| `id` | string | yes | Document/sample ID from input (Team 1). |
+| `file_path` | string | yes | S3 or local path of source file (or row origin). |
+| `band` | string | yes | Curriculum band, e.g. B0–B5 (from band_assignment). |
+| `band_reason` | string | no | Short reason for band (from band_assignment.reason). |
+| `difficulty_level` | string | no | L0–L5 (from difficulty.level). |
+| `difficulty_score` | float | no | 0.0–1.0 (from difficulty.score). |
+| `readability_fk_grade` | float | no | Flesch-Kincaid grade (from readability). |
+| `primary_modality` | string | no | text, code, math, etc. (from modality). |
+| `tokenizer_level` | string | no | T0–T5 (from tokenizer_difficulty.level). |
+| `entropy_score` | float | no | From entropy.score. |
+| `structural_density` | float | no | From structural_density.structural_density. |
+| `has_cot` | bool | no | From cot_scanner.has_cot. |
+| `has_agentic` | bool | no | From cot_scanner.has_agentic. |
+| `checksum` | string | yes | SHA-256 of normalized text (hex). |
+| `minhash` | string | no | Reserved; empty for v1. |
+| `optional_1` | string | no | Reserved for future metrics. |
+| `optional_2` | string | no | Reserved. |
+| `optional_3` | string | no | Reserved. |
+| `schema_version` | string | yes | e.g. `v1`. |
+
+**Example row:**
+
+```csv
+uuid,id,file_path,band,band_reason,difficulty_level,difficulty_score,readability_fk_grade,primary_modality,tokenizer_level,entropy_score,structural_density,has_cot,has_agentic,checksum,minhash,optional_1,optional_2,optional_3,schema_version
+a1b2c3d4-e5f6-7890-abcd-ef1234567890,sample_0,path/to/input.parquet,B1,constraint_match,L1,0.25,5.2,text,T1,3.8,0.02,false,false,a3f2b1c...,,,,v1
+```
+
+---
+
+## 2. Rejected-files log CSV
+
+**File naming:** `{output_prefix}_rejected.csv`.
+
+| Column | Type | Required | Description |
+|--------|------|----------|-------------|
+| `uuid` | string (UUID) | yes | Unique per rejected row. |
+| `id` | string | yes | Document ID from input (empty if unknown). |
+| `file_path` | string | yes | Source file path. |
+| `reason` | string | yes | One of: `parse_error`, `empty_text`, `metric_failed`, `band_assignment_failed`. |
+| `details` | string | no | Full error message or stack trace. |
+| `schema_version` | string | yes | e.g. `v1`. |
+
+**Example row:**
+
+```csv
+uuid,id,file_path,reason,details,schema_version
+c3d4e5f6-a7b8-9012-cdef-123456789012,sample_42,path/to/input.parquet,metric_failed,"TokenizerDifficultyMetric: tokenizer not found",v1
+```
+
+---
+
+## 3. Rejection reasons (enum)
+
+| Value | When used |
+|-------|-----------|
+| `parse_error` | Missing/invalid required field (e.g. no `text`). |
+| `empty_text` | Text empty or too short. |
+| `metric_failed` | A metric plugin raised or returned error. |
+| `band_assignment_failed` | Band assignment missing or error. |
+
+---
+
+## 4. Optional slots
+
+New metrics that are not yet in the fixed schema can use `optional_1`, `optional_2`, `optional_3` until the schema is extended. When adding a new fixed column, bump schema version and document in this file.

--- a/experiments/2_curirculum_architects/README.md
+++ b/experiments/2_curirculum_architects/README.md
@@ -36,7 +36,7 @@ The tagging system automatically analyzes each document and adds these labels ("
 | **Path** | `experiments/2_curirculum_architects/curriculum_tags/` |
 | **Purpose** | Auto-discovering plugin system that computes curriculum metadata tags for training datasets |
 | **Input Format** | JSONL records in Parquet files (normalized key/value pairs from Team 1) |
-| **Output** | Original Parquet files with added `curriculum_tags` field + metadata Parquet + **optional flat CSV** (main + rejected log) |
+| **Output** | **CSV only by default** (flat main CSV + rejected log). Optional pass-through Parquet (original rows, no curriculum_tags) when `write_parquet=True`. No metadata Parquet. See [OUTPUT_SCHEMA.md](./OUTPUT_SCHEMA.md). |
 
 ### Current Metrics (Plugin-Based)
 
@@ -59,17 +59,16 @@ The tagging system automatically analyzes each document and adds these labels ("
 
 ```
 ┌─────────────────┐     ┌───────────────────┐     ┌─────────────────────┐     ┌─────────────────────┐
-│  S3 Parquet     │ ──▶ │  CurriculumTagger │ ──▶ │  Tagged Parquet     │ ──▶ │  Team 3             │
-│  (from Team 1)  │     │  (runs metrics)   │     │  + Metadata File    │     │  (Coreset Eng.)     │
+│  S3 Parquet     │ ──▶ │  CurriculumTagger │ ──▶ │  Main CSV           │ ──▶ │  Team 3             │
+│  (from Team 1)  │     │  (runs metrics)   │     │  + Rejected CSV     │     │  (Coreset Eng.)     │
 └─────────────────┘     └───────────────────┘     └─────────────────────┘     └─────────────────────┘
 ```
 
-1. Read Parquet files from S3 in **distributed manner** (batch processing)
+1. Read Parquet files from S3 (or local) in **distributed manner** (batch processing)
 2. Apply each metric plugin in sequence (metrics can see results from previous metrics)
 3. Assign curriculum band (B0-B5) based on computed metrics
-4. Write processed files back to S3 with updated tags
-5. Generate separate metadata file for analytics and statistics
-6. **Optional:** Write flat main CSV (uuid, id, file_path, band, other tags, checksum, schema_version) and rejected-files CSV (uuid, id, file_path, reason, details). See [OUTPUT_SCHEMA.md](./OUTPUT_SCHEMA.md).
+4. **Default:** Write flat main CSV (uuid, id, file_path, band, other tags, checksum, schema_version) and rejected-files CSV. No Parquet output.
+5. **Optional:** Set `write_parquet=True` to also write one pass-through Parquet (original rows, no curriculum_tags). No metadata Parquet is written.
 
 ### Setup/Dependency
 

--- a/experiments/2_curirculum_architects/README.md
+++ b/experiments/2_curirculum_architects/README.md
@@ -36,7 +36,7 @@ The tagging system automatically analyzes each document and adds these labels ("
 | **Path** | `experiments/2_curirculum_architects/curriculum_tags/` |
 | **Purpose** | Auto-discovering plugin system that computes curriculum metadata tags for training datasets |
 | **Input Format** | JSONL records in Parquet files (normalized key/value pairs from Team 1) |
-| **Output** | Original Parquet files with added `curriculum_tags` field + separate metadata summary file |
+| **Output** | Original Parquet files with added `curriculum_tags` field + metadata Parquet + **optional flat CSV** (main + rejected log) |
 
 ### Current Metrics (Plugin-Based)
 
@@ -69,6 +69,7 @@ The tagging system automatically analyzes each document and adds these labels ("
 3. Assign curriculum band (B0-B5) based on computed metrics
 4. Write processed files back to S3 with updated tags
 5. Generate separate metadata file for analytics and statistics
+6. **Optional:** Write flat main CSV (uuid, id, file_path, band, other tags, checksum, schema_version) and rejected-files CSV (uuid, id, file_path, reason, details). See [OUTPUT_SCHEMA.md](./OUTPUT_SCHEMA.md).
 
 ### Setup/Dependency
 
@@ -290,6 +291,7 @@ uv run python scripts/s3_loader.py
 | Component | Path |
 |-----------|------|
 | Curriculum Policy | [`curriculum.yaml`](./curriculum.yaml) |
+| Output Schema (CSV) | [`OUTPUT_SCHEMA.md`](./OUTPUT_SCHEMA.md) |
 | Metrics Config | [`metrics_config.yaml`](./metrics_config.yaml) |
 | Tagging Library | [`metrics/README.md`](./curriculum_tags/metrics/README.md) |
 | Data Sampler | [`data_sampler/README.md`](./data_sampler/README.md) |

--- a/experiments/2_curirculum_architects/curriculum_tags/core/tagger.py
+++ b/experiments/2_curirculum_architects/curriculum_tags/core/tagger.py
@@ -126,7 +126,6 @@ class CurriculumTagger:
         for plugin in self.plugins:
             try:
                 tags = plugin.compute(sample)
-                print(f"id: {sample['id']}, tags: {tags}")
                 sample["curriculum_tags"][plugin.name] = tags
             except Exception as e:
                 sample["curriculum_tags"][plugin.name] = {"error": str(e)}
@@ -142,6 +141,7 @@ class CurriculumTagger:
         output_path: str | Path,
         batch_size: int = 10000,
         progress_callback: Optional[Callable[[int], None]] = None,
+        output_csv_path: Optional[str | Path] = None,
     ) -> Dict[str, Any]:
         """Process parquet file and add curriculum tags.
 
@@ -150,6 +150,7 @@ class CurriculumTagger:
             output_path: Output parquet file
             batch_size: Number of rows per batch
             progress_callback: Optional callback for progress (total_rows)
+            output_csv_path: If set, write flat main CSV and rejected CSV alongside Parquet
 
         Returns:
             Statistics about processing (rows, errors, etc.)
@@ -169,6 +170,7 @@ class CurriculumTagger:
         # Process in batches
         output_batches = []
         metadata_batches = []
+        all_tagged_records: List[Dict[str, Any]] = []
         total_rows = 0
         error_count = 0
 
@@ -191,6 +193,8 @@ class CurriculumTagger:
                     }
                     tagged_records.append(record)
                     error_count += 1
+
+            all_tagged_records.extend(tagged_records)
 
             # Prepare metadata records (id, curriculum_tags)
             for tagged in tagged_records:
@@ -215,11 +219,27 @@ class CurriculumTagger:
         metadata_table = pa.concat_tables(metadata_batches)
         pq.write_table(metadata_table, metadata_path)
 
-        return {
+        result: Dict[str, Any] = {
             "total_rows": total_rows,
             "error_count": error_count,
             "output_file": str(output_path),
         }
+
+        # Optional: write flat CSV (main + rejected)
+        if output_csv_path is not None:
+            from ..output.csv_writer import write_csv_output
+
+            csv_stats = write_csv_output(
+                all_tagged_records,
+                file_path=str(input_path),
+                output_csv_path=Path(output_csv_path),
+            )
+            result["main_csv_path"] = csv_stats["main_csv_path"]
+            result["rejected_csv_path"] = csv_stats["rejected_csv_path"]
+            result["main_csv_rows"] = csv_stats["main_row_count"]
+            result["rejected_csv_rows"] = csv_stats["rejected_row_count"]
+
+        return result
 
     def process_parquet_s3(
         self,
@@ -228,6 +248,7 @@ class CurriculumTagger:
         filesystem,
         batch_size: int = 10000,
         progress_callback: Optional[Callable[[int], None]] = None,
+        output_csv_path: Optional[str | Path] = None,
     ) -> dict:
         """Process S3 parquet file and add curriculum tags + metadata parquet."""
 
@@ -246,6 +267,7 @@ class CurriculumTagger:
 
         output_batches = []
         metadata_batches = []
+        all_tagged_records: List[Dict[str, Any]] = []
         total_rows = 0
         error_count = 0
 
@@ -268,6 +290,8 @@ class CurriculumTagger:
                     }
                     tagged_records.append(record)
                     error_count += 1
+
+            all_tagged_records.extend(tagged_records)
 
             # Prepare metadata records (id, curriculum_tags)
             for tagged in tagged_records:
@@ -300,12 +324,28 @@ class CurriculumTagger:
             pq.write_table(metadata_table, f)
         filesystem.mv(tmp_meta, metadata_path)
 
-        return {
+        result: Dict[str, Any] = {
             "total_rows": total_rows,
             "error_count": error_count,
             "output_file": output_path,
             "metadata_file": metadata_path,
         }
+
+        # Optional: write flat CSV (main + rejected) to local path
+        if output_csv_path is not None:
+            from ..output.csv_writer import write_csv_output
+
+            csv_stats = write_csv_output(
+                all_tagged_records,
+                file_path=input_path,
+                output_csv_path=Path(output_csv_path),
+            )
+            result["main_csv_path"] = csv_stats["main_csv_path"]
+            result["rejected_csv_path"] = csv_stats["rejected_csv_path"]
+            result["main_csv_rows"] = csv_stats["main_row_count"]
+            result["rejected_csv_rows"] = csv_stats["rejected_row_count"]
+
+        return result
 
     def process_batch(self, samples: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Process a batch of samples in memory.

--- a/experiments/2_curirculum_architects/curriculum_tags/core/tagger.py
+++ b/experiments/2_curirculum_architects/curriculum_tags/core/tagger.py
@@ -138,55 +138,60 @@ class CurriculumTagger:
     def process_parquet(
         self,
         input_path: str | Path,
-        output_path: str | Path,
+        output_path: Optional[str | Path] = None,
         batch_size: int = 10000,
         progress_callback: Optional[Callable[[int], None]] = None,
         output_csv_path: Optional[str | Path] = None,
+        rejected_csv_path: Optional[str | Path] = None,
+        write_parquet: bool = False,
     ) -> Dict[str, Any]:
         """Process parquet file and add curriculum tags.
 
+        By default only CSV output is written (main + rejected). Parquet output
+        is optional and when enabled is pass-through (original rows, no curriculum_tags).
+
         Args:
             input_path: Input parquet file
-            output_path: Output parquet file
+            output_path: Output parquet file (required only when write_parquet=True)
             batch_size: Number of rows per batch
             progress_callback: Optional callback for progress (total_rows)
-            output_csv_path: If set, write flat main CSV and rejected CSV alongside Parquet
+            output_csv_path: If set, write flat main CSV and rejected CSV
+            rejected_csv_path: If set, path for rejected log CSV; else derived from output_csv_path
+            write_parquet: If True, write one Parquet at output_path with original rows
+                (no curriculum_tags). No metadata Parquet is written. Default False.
 
         Returns:
-            Statistics about processing (rows, errors, etc.)
+            Statistics: total_rows, error_count; output_file only if write_parquet;
+            main_csv_path, rejected_csv_path, main_csv_rows, rejected_csv_rows if CSV written.
         """
         input_path = Path(input_path)
-        output_path = Path(output_path)
 
         if not input_path.exists():
             raise FileNotFoundError(f"Input file not found: {input_path}")
 
-        # Prepare metadata parquet output path
-        metadata_path = output_path.with_suffix(".metadata.parquet")
+        if write_parquet and output_path is None:
+            raise ValueError("output_path is required when write_parquet=True")
+
+        if output_path is not None:
+            output_path = Path(output_path)
 
         # Read parquet file
         parquet_file = pq.ParquetFile(input_path)
 
-        # Process in batches
-        output_batches = []
-        metadata_batches = []
         all_tagged_records: List[Dict[str, Any]] = []
+        all_original_records: List[Dict[str, Any]] = []  # rows without curriculum_tags
         total_rows = 0
         error_count = 0
 
         for batch in parquet_file.iter_batches(batch_size=batch_size):
-            # Convert to Python dicts
             records = batch.to_pylist()
 
-            # Tag each record
             tagged_records = []
-            meta_records = []
             for record in records:
                 try:
                     tagged = self.tag_sample(record)
                     tagged_records.append(tagged)
                 except Exception as e:
-                    # Keep original record but mark error
                     record["curriculum_tags"] = {
                         "version": self.config.version,
                         "error": str(e),
@@ -195,37 +200,25 @@ class CurriculumTagger:
                     error_count += 1
 
             all_tagged_records.extend(tagged_records)
-
-            # Prepare metadata records (id, curriculum_tags)
+            # Pass-through: rows without curriculum_tags for optional Parquet output
             for tagged in tagged_records:
-                meta_records.append({"id": tagged.get("id"), "curriculum_tags": tagged.get("curriculum_tags", {})})
-
-            # Convert back to Arrow tables
-            tagged_batch = pa.Table.from_pylist(tagged_records)
-            meta_batch = pa.Table.from_pylist(meta_records)
-            output_batches.append(tagged_batch)
-            metadata_batches.append(meta_batch)
+                all_original_records.append({k: v for k, v in tagged.items() if k != "curriculum_tags"})
 
             total_rows += len(records)
 
             if progress_callback:
                 progress_callback(total_rows)
 
-        # Combine and write
-        output_table = pa.concat_tables(output_batches)
-        pq.write_table(output_table, output_path)
-
-        # Combine and write metadata table
-        metadata_table = pa.concat_tables(metadata_batches)
-        pq.write_table(metadata_table, metadata_path)
-
         result: Dict[str, Any] = {
             "total_rows": total_rows,
             "error_count": error_count,
-            "output_file": str(output_path),
         }
 
-        # Optional: write flat CSV (main + rejected)
+        if write_parquet and output_path is not None:
+            output_table = pa.Table.from_pylist(all_original_records)
+            pq.write_table(output_table, output_path)
+            result["output_file"] = str(output_path)
+
         if output_csv_path is not None:
             from ..output.csv_writer import write_csv_output
 
@@ -233,6 +226,7 @@ class CurriculumTagger:
                 all_tagged_records,
                 file_path=str(input_path),
                 output_csv_path=Path(output_csv_path),
+                rejected_csv_path=Path(rejected_csv_path) if rejected_csv_path is not None else None,
             )
             result["main_csv_path"] = csv_stats["main_csv_path"]
             result["rejected_csv_path"] = csv_stats["rejected_csv_path"]
@@ -244,46 +238,47 @@ class CurriculumTagger:
     def process_parquet_s3(
         self,
         input_path: str,
-        output_path: str,
-        filesystem,
+        output_path: Optional[str] = None,
+        filesystem=None,
         batch_size: int = 10000,
         progress_callback: Optional[Callable[[int], None]] = None,
         output_csv_path: Optional[str | Path] = None,
+        rejected_csv_path: Optional[str | Path] = None,
+        write_parquet: bool = False,
     ) -> dict:
-        """Process S3 parquet file and add curriculum tags + metadata parquet."""
+        """Process S3 parquet file; by default only CSV output (main + rejected).
 
-        # ---- Validate paths (S3 equivalent of Path.exists()) ----
+        When write_parquet=True, writes one pass-through Parquet (original rows,
+        no curriculum_tags) to output_path. No metadata Parquet is written.
+        """
+
         if not filesystem.exists(input_path):
             raise FileNotFoundError(f"S3 input not found: {input_path}")
 
-        output_prefix = output_path.rsplit("/", 1)[0]
-        if not filesystem.exists(output_prefix):
-            raise FileNotFoundError(f"S3 output prefix not found: {output_prefix}")
+        if write_parquet and output_path is None:
+            raise ValueError("output_path is required when write_parquet=True")
 
-        # Metadata path (string version of .with_suffix())
-        metadata_path = output_path.replace(".parquet", ".metadata.parquet")
+        if write_parquet and output_path is not None:
+            output_prefix = output_path.rsplit("/", 1)[0]
+            if not filesystem.exists(output_prefix):
+                raise FileNotFoundError(f"S3 output prefix not found: {output_prefix}")
 
         parquet_file = pq.ParquetFile(input_path, filesystem=filesystem)
 
-        output_batches = []
-        metadata_batches = []
         all_tagged_records: List[Dict[str, Any]] = []
+        all_original_records: List[Dict[str, Any]] = []
         total_rows = 0
         error_count = 0
 
         for batch in parquet_file.iter_batches(batch_size=batch_size):
-            # Convert to Python dicts
             records = batch.to_pylist()
 
-            # Tag each record
             tagged_records = []
-            meta_records = []
             for record in records:
                 try:
                     tagged = self.tag_sample(record)
                     tagged_records.append(tagged)
                 except Exception as e:
-                    # Keep original record but mark error
                     record["curriculum_tags"] = {
                         "version": self.config.version,
                         "error": str(e),
@@ -292,46 +287,27 @@ class CurriculumTagger:
                     error_count += 1
 
             all_tagged_records.extend(tagged_records)
-
-            # Prepare metadata records (id, curriculum_tags)
             for tagged in tagged_records:
-                meta_records.append({"id": tagged.get("id"), "curriculum_tags": tagged.get("curriculum_tags", {})})
-
-            # Convert back to Arrow tables
-            tagged_batch = pa.Table.from_pylist(tagged_records)
-            meta_batch = pa.Table.from_pylist(meta_records)
-            output_batches.append(tagged_batch)
-            metadata_batches.append(meta_batch)
+                all_original_records.append({k: v for k, v in tagged.items() if k != "curriculum_tags"})
 
             total_rows += len(records)
 
             if progress_callback:
                 progress_callback(total_rows)
 
-        # Combine and write
-        output_table = pa.concat_tables(output_batches)
-        metadata_table = pa.concat_tables(metadata_batches)
-
-        # Atomic write main parquet to s3
-        tmp_output = output_path + ".tmp"
-        with filesystem.open(tmp_output, "wb") as f:
-            pq.write_table(output_table, f)
-        filesystem.mv(tmp_output, output_path)
-
-        # Atomic write metadata parquet to s3
-        tmp_meta = metadata_path + ".tmp"
-        with filesystem.open(tmp_meta, "wb") as f:
-            pq.write_table(metadata_table, f)
-        filesystem.mv(tmp_meta, metadata_path)
-
         result: Dict[str, Any] = {
             "total_rows": total_rows,
             "error_count": error_count,
-            "output_file": output_path,
-            "metadata_file": metadata_path,
         }
 
-        # Optional: write flat CSV (main + rejected) to local path
+        if write_parquet and output_path is not None:
+            output_table = pa.Table.from_pylist(all_original_records)
+            tmp_output = output_path + ".tmp"
+            with filesystem.open(tmp_output, "wb") as f:
+                pq.write_table(output_table, f)
+            filesystem.mv(tmp_output, output_path)
+            result["output_file"] = output_path
+
         if output_csv_path is not None:
             from ..output.csv_writer import write_csv_output
 
@@ -339,6 +315,7 @@ class CurriculumTagger:
                 all_tagged_records,
                 file_path=input_path,
                 output_csv_path=Path(output_csv_path),
+                rejected_csv_path=Path(rejected_csv_path) if rejected_csv_path is not None else None,
             )
             result["main_csv_path"] = csv_stats["main_csv_path"]
             result["rejected_csv_path"] = csv_stats["rejected_csv_path"]

--- a/experiments/2_curirculum_architects/curriculum_tags/output/__init__.py
+++ b/experiments/2_curirculum_architects/curriculum_tags/output/__init__.py
@@ -1,0 +1,13 @@
+"""Output schema and CSV writer for curriculum tagging pipeline."""
+
+from .csv_writer import is_rejected, write_csv_output
+from .schema import MAIN_CSV_COLUMNS, REJECTED_CSV_COLUMNS, SCHEMA_VERSION, RejectionReason
+
+__all__ = [
+    "MAIN_CSV_COLUMNS",
+    "REJECTED_CSV_COLUMNS",
+    "SCHEMA_VERSION",
+    "RejectionReason",
+    "write_csv_output",
+    "is_rejected",
+]

--- a/experiments/2_curirculum_architects/curriculum_tags/output/csv_writer.py
+++ b/experiments/2_curirculum_architects/curriculum_tags/output/csv_writer.py
@@ -1,0 +1,154 @@
+"""CSV writer: flatten curriculum_tags to flat columns and write main + rejected CSVs."""
+
+import csv
+import hashlib
+import uuid as uuid_module
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .schema import MAIN_CSV_COLUMNS, REJECTED_CSV_COLUMNS, SCHEMA_VERSION, RejectionReason
+
+
+def compute_checksum(text: str) -> str:
+    """SHA-256 of normalized text (strip, UTF-8). Empty string -> hash of empty."""
+    normalized = (text or "").strip()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def is_rejected(record: Dict[str, Any]) -> bool:
+    """True if this record has an error or no band (should go to rejected log only)."""
+    tags = record.get("curriculum_tags") or {}
+    if tags.get("error") is not None:
+        return True
+    band_assignment = tags.get("band_assignment") or {}
+    band = band_assignment.get("band")
+    if band is None or band == "":
+        return True
+    return False
+
+
+def _get_rejection_reason_and_details(record: Dict[str, Any]) -> tuple[str, str]:
+    """Infer reason and details from curriculum_tags.error or band_assignment."""
+    tags = record.get("curriculum_tags") or {}
+    err = tags.get("error")
+    if err is not None:
+        return RejectionReason.METRIC_FAILED.value, str(err)
+    band_assignment = tags.get("band_assignment") or {}
+    if band_assignment.get("band") is None:
+        return RejectionReason.BAND_ASSIGNMENT_FAILED.value, "band missing"
+    return RejectionReason.METRIC_FAILED.value, "unknown"
+
+
+def flatten_record(record: Dict[str, Any], file_path: str) -> Dict[str, str]:
+    """Build one flat main-CSV row from a tagged record. Assumes record is not rejected."""
+    tags = record.get("curriculum_tags") or {}
+    text = record.get("text") or ""
+
+    band_assignment = tags.get("band_assignment") or {}
+    difficulty = tags.get("difficulty") or {}
+    readability = tags.get("readability") or {}
+    modality = tags.get("modality") or {}
+    tokenizer_difficulty = tags.get("tokenizer_difficulty") or {}
+    entropy = tags.get("entropy") or {}
+    structural_density = tags.get("structural_density") or {}
+    cot_scanner = tags.get("cot_scanner") or {}
+
+    def b(v: Any) -> str:
+        if v is True:
+            return "true"
+        if v is False:
+            return "false"
+        return str(v) if v != "" and v is not None else ""
+
+    return {
+        "uuid": str(uuid_module.uuid4()),
+        "id": str(record.get("id", "")),
+        "file_path": file_path,
+        "band": str(band_assignment.get("band", "")),
+        "band_reason": str(band_assignment.get("reason", "")),
+        "difficulty_level": str(difficulty.get("level", "")),
+        "difficulty_score": str(difficulty.get("score", "")),
+        "readability_fk_grade": str(readability.get("flesch_kincaid_grade", "")),
+        "primary_modality": str(modality.get("primary_modality", "")),
+        "tokenizer_level": str(tokenizer_difficulty.get("level", "")),
+        "entropy_score": str(entropy.get("score", "")),
+        "structural_density": str(structural_density.get("structural_density", "")),
+        "has_cot": b(cot_scanner.get("has_cot")),
+        "has_agentic": b(cot_scanner.get("has_agentic")),
+        "checksum": compute_checksum(text),
+        "minhash": "",
+        "optional_1": "",
+        "optional_2": "",
+        "optional_3": "",
+        "schema_version": SCHEMA_VERSION,
+    }
+
+
+def build_rejected_row(
+    record: Dict[str, Any],
+    file_path: str,
+    reason: str,
+    details: str,
+) -> Dict[str, str]:
+    """Build one rejected-log row."""
+    return {
+        "uuid": str(uuid_module.uuid4()),
+        "id": str(record.get("id", "")),
+        "file_path": file_path,
+        "reason": reason,
+        "details": details,
+        "schema_version": SCHEMA_VERSION,
+    }
+
+
+def write_csv_output(
+    tagged_records: List[Dict[str, Any]],
+    file_path: str,
+    output_csv_path: str | Path,
+    rejected_csv_path: Optional[str | Path] = None,
+) -> Dict[str, Any]:
+    """Write main CSV and rejected CSV from tagged records.
+
+    Args:
+        tagged_records: List of records with curriculum_tags (and id, text).
+        file_path: Source file path to put in file_path column (same for all rows in this batch).
+        output_csv_path: Path for main CSV.
+        rejected_csv_path: Path for rejected log; if None, derived from output_csv_path.
+
+    Returns:
+        Dict with keys: main_csv_path, rejected_csv_path, main_row_count, rejected_row_count.
+    """
+    output_csv_path = Path(output_csv_path)
+    if rejected_csv_path is None:
+        stem = output_csv_path.stem
+        parent = output_csv_path.parent
+        rejected_csv_path = parent / f"{stem}_rejected.csv"
+    else:
+        rejected_csv_path = Path(rejected_csv_path)
+
+    main_rows: List[Dict[str, str]] = []
+    rejected_rows: List[Dict[str, str]] = []
+
+    for record in tagged_records:
+        if is_rejected(record):
+            reason, details = _get_rejection_reason_and_details(record)
+            rejected_rows.append(build_rejected_row(record, file_path, reason, details))
+        else:
+            main_rows.append(flatten_record(record, file_path))
+
+    def write_csv(path: Path, columns: List[str], rows: List[Dict[str, str]]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=columns, extrasaction="ignore")
+            writer.writeheader()
+            writer.writerows(rows)
+
+    write_csv(output_csv_path, MAIN_CSV_COLUMNS, main_rows)
+    write_csv(rejected_csv_path, REJECTED_CSV_COLUMNS, rejected_rows)
+
+    return {
+        "main_csv_path": str(output_csv_path),
+        "rejected_csv_path": str(rejected_csv_path),
+        "main_row_count": len(main_rows),
+        "rejected_row_count": len(rejected_rows),
+    }

--- a/experiments/2_curirculum_architects/curriculum_tags/output/schema.py
+++ b/experiments/2_curirculum_architects/curriculum_tags/output/schema.py
@@ -1,0 +1,49 @@
+"""Output schema constants for main CSV and rejected log."""
+
+from enum import Enum
+from typing import List
+
+SCHEMA_VERSION = "v1"
+
+# Main CSV columns (order matters for header and row writing)
+MAIN_CSV_COLUMNS: List[str] = [
+    "uuid",
+    "id",
+    "file_path",
+    "band",
+    "band_reason",
+    "difficulty_level",
+    "difficulty_score",
+    "readability_fk_grade",
+    "primary_modality",
+    "tokenizer_level",
+    "entropy_score",
+    "structural_density",
+    "has_cot",
+    "has_agentic",
+    "checksum",
+    "minhash",
+    "optional_1",
+    "optional_2",
+    "optional_3",
+    "schema_version",
+]
+
+# Rejected log CSV columns
+REJECTED_CSV_COLUMNS: List[str] = [
+    "uuid",
+    "id",
+    "file_path",
+    "reason",
+    "details",
+    "schema_version",
+]
+
+
+class RejectionReason(str, Enum):
+    """Standard reasons for rejecting a row (no band/tags written to main output)."""
+
+    PARSE_ERROR = "parse_error"
+    EMPTY_TEXT = "empty_text"
+    METRIC_FAILED = "metric_failed"
+    BAND_ASSIGNMENT_FAILED = "band_assignment_failed"

--- a/experiments/2_curirculum_architects/examples/parquet_processing.py
+++ b/experiments/2_curirculum_architects/examples/parquet_processing.py
@@ -1,5 +1,10 @@
-"""Example of processing parquet files with curriculum tags."""
+"""Example of processing parquet files with curriculum tags.
 
+By default only CSV output is written (main + rejected). Set write_parquet=True
+to also write pass-through Parquet (original rows, no curriculum_tags).
+"""
+
+import csv
 import tempfile
 from pathlib import Path
 
@@ -8,8 +13,9 @@ import pyarrow.parquet as pq
 
 from curriculum_tags import CurriculumTagger
 
-CSV_OUTPUT_PATH = Path(__file__).parent.parent / "processed_data" / "output.csv"
-REJECTED_CSV_OUTPUT_PATH = Path(__file__).parent.parent / "processed_data" / "rejected.csv"
+PROCESSED_DATA_DIR = Path(__file__).parent.parent / "processed_data"
+CSV_OUTPUT_PATH = PROCESSED_DATA_DIR / "output.csv"
+REJECTED_CSV_OUTPUT_PATH = PROCESSED_DATA_DIR / "rejected.csv"
 
 
 def create_sample_data(output_path: Path, num_samples: int = 100):
@@ -48,10 +54,11 @@ def process_parquet_demo():
     # Path relative to this example file
     curriculum_path = Path(__file__).parent.parent / "curriculum.yaml"
 
-    # Create temporary files
+    # Input in temp dir; CSV output to processed_data folder
+    PROCESSED_DATA_DIR.mkdir(parents=True, exist_ok=True)
+
     with tempfile.TemporaryDirectory() as tmpdir:
         input_file = Path(tmpdir) / "input.parquet"
-        output_file = Path(tmpdir) / "output.parquet"
 
         # Create sample data
         print("\n1. Creating sample dataset...")
@@ -61,8 +68,8 @@ def process_parquet_demo():
         print("\n2. Initializing tagger...")
         tagger = CurriculumTagger(curriculum_path)
 
-        # Process file
-        print("\n3. Processing parquet file...")
+        # Process file (CSV only by default; output to processed_data)
+        print("\n3. Processing parquet file (CSV output to processed_data)...")
 
         processed_count = [0]
 
@@ -71,51 +78,44 @@ def process_parquet_demo():
             if total % 50 == 0:
                 print(f"   Processed {total} rows...")
 
-        output_csv = CSV_OUTPUT_PATH
         stats = tagger.process_parquet(
             input_path=input_file,
-            output_path=output_file,
             batch_size=25,
             progress_callback=progress_callback,
-            output_csv_path=output_csv,
+            output_csv_path=CSV_OUTPUT_PATH,
+            rejected_csv_path=REJECTED_CSV_OUTPUT_PATH,
+            write_parquet=False,
         )
         print("\n4. Processing complete!")
         print(f"   Total rows: {stats['total_rows']}")
         print(f"   Errors: {stats['error_count']}")
-        print(f"   Output file: {stats['output_file']}")
         if "main_csv_path" in stats:
             print(f"   Main CSV: {stats['main_csv_path']} ({stats.get('main_csv_rows', 0)} rows)")
             print(f"   Rejected CSV: {stats['rejected_csv_path']} ({stats.get('rejected_csv_rows', 0)} rows)")
+        if "output_file" in stats:
+            print(f"   Parquet: {stats['output_file']}")
 
-        # Read and display sample results
-        print("\n5. Sample tagged results:")
+        # Show first 3 rows from main CSV (in processed_data)
+        print("\n5. Sample tagged results (from CSV in processed_data):")
         print("=" * 80)
 
-        result_table = pq.read_table(output_file)
-        result_data = result_table.to_pylist()
-
-        # Show first 3 samples
-        for i, row in enumerate(result_data[:3]):
-            print(f"\nSample {i+1}:")
-            print(f"  ID: {row['id']}")
-            print(f"  Text: {row['text'][:50]}...")
-
-            tags = row["curriculum_tags"]
-            print(f"  Curriculum Version: {tags['version']}")
-
-            if "band_assignment" in tags:
-                ba = tags["band_assignment"]
-                print(f"  Band: {ba.get('band', '—')}")
-
-            if "difficulty" in tags:
-                diff = tags["difficulty"]
-                print(f"  Difficulty Level: {diff.get('level', '—')} (score: {diff.get('score', '—')})")
-
-            if "modality" in tags:
-                mod = tags["modality"]
-                print(f"  Primary Modality: {mod.get('primary_modality', '—')}")
-
-            print("-" * 80)
+        main_csv = stats.get("main_csv_path")
+        if main_csv and Path(main_csv).exists():
+            with open(main_csv, newline="", encoding="utf-8") as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+            for i, row in enumerate(rows[:3]):
+                print(f"\nSample {i+1}:")
+                print(f"  id: {row.get('id', '—')}")
+                print(f"  file_path: {row.get('file_path', '—')}")
+                print(f"  band: {row.get('band', '—')}")
+                print(
+                    f"  difficulty_level: {row.get('difficulty_level', '—')} (score: {row.get('difficulty_score', '—')})"
+                )
+                print(f"  primary_modality: {row.get('primary_modality', '—')}")
+                print("-" * 80)
+        else:
+            print("  (No main CSV path in stats or file missing)")
 
 
 if __name__ == "__main__":

--- a/experiments/2_curirculum_architects/examples/parquet_processing.py
+++ b/experiments/2_curirculum_architects/examples/parquet_processing.py
@@ -8,6 +8,9 @@ import pyarrow.parquet as pq
 
 from curriculum_tags import CurriculumTagger
 
+CSV_OUTPUT_PATH = Path(__file__).parent.parent / "processed_data" / "output.csv"
+REJECTED_CSV_OUTPUT_PATH = Path(__file__).parent.parent / "processed_data" / "rejected.csv"
+
 
 def create_sample_data(output_path: Path, num_samples: int = 100):
     """Create sample parquet file for demonstration."""
@@ -68,16 +71,21 @@ def process_parquet_demo():
             if total % 50 == 0:
                 print(f"   Processed {total} rows...")
 
+        output_csv = CSV_OUTPUT_PATH
         stats = tagger.process_parquet(
             input_path=input_file,
             output_path=output_file,
             batch_size=25,
             progress_callback=progress_callback,
+            output_csv_path=output_csv,
         )
         print("\n4. Processing complete!")
         print(f"   Total rows: {stats['total_rows']}")
         print(f"   Errors: {stats['error_count']}")
         print(f"   Output file: {stats['output_file']}")
+        if "main_csv_path" in stats:
+            print(f"   Main CSV: {stats['main_csv_path']} ({stats.get('main_csv_rows', 0)} rows)")
+            print(f"   Rejected CSV: {stats['rejected_csv_path']} ({stats.get('rejected_csv_rows', 0)} rows)")
 
         # Read and display sample results
         print("\n5. Sample tagged results:")
@@ -95,13 +103,17 @@ def process_parquet_demo():
             tags = row["curriculum_tags"]
             print(f"  Curriculum Version: {tags['version']}")
 
+            if "band_assignment" in tags:
+                ba = tags["band_assignment"]
+                print(f"  Band: {ba.get('band', '—')}")
+
             if "difficulty" in tags:
                 diff = tags["difficulty"]
-                print(f"  Difficulty Band: {diff['band']}")
+                print(f"  Difficulty Level: {diff.get('level', '—')} (score: {diff.get('score', '—')})")
 
             if "modality" in tags:
                 mod = tags["modality"]
-                print(f"  Primary Modality: {mod['primary_modality']}")
+                print(f"  Primary Modality: {mod.get('primary_modality', '—')}")
 
             print("-" * 80)
 

--- a/experiments/2_curirculum_architects/scripts/s3_loader.py
+++ b/experiments/2_curirculum_architects/scripts/s3_loader.py
@@ -4,6 +4,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+import pyarrow.parquet as pq
 import ray
 import s3fs
 from tqdm import tqdm
@@ -15,6 +16,9 @@ from curriculum_tags import CurriculumTagger
 # ------------------------------------------------------------------------------
 INPUT_S3_PREFIX = "s3://smita-erav4/parquet_raw"
 OUTPUT_S3_PREFIX = "s3://smita-erav4/parquet_processed"
+# Local directory for CSV output (default: CSV only, no Parquet to S3)
+OUTPUT_CSV_DIR = Path("./csv_output")
+WRITE_PARQUET = False  # Set True to write pass-through Parquet to S3
 
 # Absolute path to the curriculum config
 CURRICULUM_YAML = str(Path(__file__).parent.parent / "curriculum.yaml")
@@ -29,11 +33,11 @@ MAX_FILES = None  # Set to None for unlimited, or a number to limit the run
 # Logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s [%(levelname)s] %(message)s',
+    format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[
         logging.FileHandler(f"tagging_run_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"),
-        logging.StreamHandler()
-    ]
+        logging.StreamHandler(),
+    ],
 )
 logger = logging.getLogger(__name__)
 
@@ -43,6 +47,7 @@ logger = logging.getLogger(__name__)
 if not ray.is_initialized():
     ray.init(num_cpus=NUM_CPUS, ignore_reinit_error=True)
 
+
 # ------------------------------------------------------------------------------
 # PROCESS ONE FILE (Ray Task)
 # ------------------------------------------------------------------------------
@@ -50,42 +55,43 @@ if not ray.is_initialized():
 def process_s3_file(file_path: str) -> dict:
     """Processes a single parquet file directly from S3."""
     fs = s3fs.S3FileSystem()
-    
+
     # Use print instead of logger for Ray worker visibility
     print(f"  [Worker {os.getpid()}] STARTING: {file_path}")
-    
+
     try:
-        tagger = CurriculumTagger(
-            curriculum_path=CURRICULUM_YAML,
-            metrics_config_path=METRICS_CONFIG
-        )
+        tagger = CurriculumTagger(curriculum_path=CURRICULUM_YAML, metrics_config_path=METRICS_CONFIG)
     except Exception as e:
         return {"file": file_path, "status": "init_failed", "error": str(e)}
 
-    # Map input path to output path
+    # Map input path to output paths
     input_prefix = INPUT_S3_PREFIX.replace("s3://", "")
     relative_path = file_path.replace(input_prefix, "").lstrip("/")
-    output_file = f"{OUTPUT_S3_PREFIX.rstrip('/')}/{relative_path}"
+    output_file = f"{OUTPUT_S3_PREFIX.rstrip('/')}/{relative_path}" if WRITE_PARQUET else None
+
+    # Local CSV path (CSV output only by default)
+    local_csv_path = OUTPUT_CSV_DIR / relative_path.replace(".parquet", ".csv")
+    local_csv_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Get total expected rows for percentage reporting
     try:
         total_expected_rows = pq.ParquetFile(f"s3://{file_path}", filesystem=fs).metadata.num_rows
-    except:
+    except Exception:
         total_expected_rows = 0
 
     start_time = time.time()
-    
+
     def heartbeat_callback(rows):
         """Logs status every 10 seconds for long-running files."""
-        # We use a simple attribute on the callback function to track time
         now = time.time()
-        if not hasattr(heartbeat_callback, 'last_log'):
+        if not hasattr(heartbeat_callback, "last_log"):
             heartbeat_callback.last_log = now
-        
         if now - heartbeat_callback.last_log > 10:
             elapsed = now - start_time
             pct = (rows / total_expected_rows) * 100 if total_expected_rows > 0 else 0
-            print(f"  [Worker {os.getpid()}] HEARTBEAT: {file_path} | {rows:,}/{total_expected_rows:,} ({pct:.1f}%) | {elapsed:.0f}s elapsed")
+            print(
+                f"  [Worker {os.getpid()}] HEARTBEAT: {file_path} | {rows:,}/{total_expected_rows:,} ({pct:.1f}%) | {elapsed:.0f}s elapsed"
+            )
             heartbeat_callback.last_log = now
 
     try:
@@ -94,18 +100,22 @@ def process_s3_file(file_path: str) -> dict:
             output_path=output_file,
             filesystem=fs,
             batch_size=BATCH_SIZE,
-            progress_callback=heartbeat_callback
+            progress_callback=heartbeat_callback,
+            output_csv_path=local_csv_path,
+            write_parquet=WRITE_PARQUET,
         )
-        
+
         duration = time.time() - start_time
-        return {
+        result = {
             "input_file": file_path,
-            "output_file": output_file,
             "status": "success",
             "duration_sec": round(duration, 2),
-            "rows_per_sec": round(stats['total_rows'] / duration, 2) if duration > 0 else 0,
+            "rows_per_sec": round(stats["total_rows"] / duration, 2) if duration > 0 else 0,
             **stats,
         }
+        if output_file is not None:
+            result["output_file"] = output_file
+        return result
 
     except Exception as e:
         return {
@@ -115,16 +125,17 @@ def process_s3_file(file_path: str) -> dict:
             "error": str(e),
         }
 
+
 # ------------------------------------------------------------------------------
-# MAIN PIPELINE 
+# MAIN PIPELINE
 # ------------------------------------------------------------------------------
 def process_s3_bucket():
     fs = s3fs.S3FileSystem()
-    
+
     logger.info(f"Scanning S3 bucket: {INPUT_S3_PREFIX}")
     # List all parquet files recursively
     all_inputs = [f for f in fs.glob(f"{INPUT_S3_PREFIX}/**/*.parquet") if not f.endswith(".metadata.parquet")]
-    
+
     if not all_inputs:
         logger.error("No parquet files found in the specified S3 path.")
         return
@@ -135,15 +146,20 @@ def process_s3_bucket():
     for f in all_inputs:
         input_prefix = INPUT_S3_PREFIX.replace("s3://", "")
         rel = f.replace(input_prefix, "").lstrip("/")
-        out = f"{OUTPUT_S3_PREFIX.rstrip('/')}/{rel}"
-        
-        if fs.exists(out):
-            continue
+        if WRITE_PARQUET:
+            out = f"{OUTPUT_S3_PREFIX.rstrip('/')}/{rel}"
+            if fs.exists(out):
+                continue
+        else:
+            # CSV-only: skip if local CSV exists
+            local_csv = OUTPUT_CSV_DIR / rel.replace(".parquet", ".csv")
+            if local_csv.exists():
+                continue
         to_process.append(f)
 
     logger.info(f"Total files in source: {len(all_inputs)}")
     logger.info(f"Files already processed: {len(all_inputs) - len(to_process)}")
-    
+
     if MAX_FILES is not None:
         to_process = to_process[:MAX_FILES]
         logger.info(f"Capping processing to {MAX_FILES} files due to MAX_FILES setting.")
@@ -173,26 +189,30 @@ def process_s3_bucket():
 
     while pending:
         done_ids, pending = ray.wait(pending, num_returns=1)
-        
+
         for result_id in done_ids:
             res = ray.get(result_id)
-            
+
             if res["status"] == "success":
                 success_count += 1
-                total_rows_processed += res.get('total_rows', 0)
+                total_rows_processed += res.get("total_rows", 0)
                 # Periodic logging for big runs
                 if success_count % 10 == 0:
-                    logger.info(f"Progress: {success_count}/{len(to_process)} files | Total Rows: {total_rows_processed}")
+                    logger.info(
+                        f"Progress: {success_count}/{len(to_process)} files | Total Rows: {total_rows_processed}"
+                    )
             else:
                 failures.append(res)
                 logger.error(f"Failed file: {res.get('input_file')} | Error: {res.get('error')}")
 
             pbar.update(1)
-            pbar.set_postfix({
-                "rows": f"{total_rows_processed:,}",
-                "fails": len(failures),
-                "last_speed": f"{res.get('rows_per_sec', 0):.0f} r/s" if res["status"] == "success" else "ERR"
-            })
+            pbar.set_postfix(
+                {
+                    "rows": f"{total_rows_processed:,}",
+                    "fails": len(failures),
+                    "last_speed": f"{res.get('rows_per_sec', 0):.0f} r/s" if res["status"] == "success" else "ERR",
+                }
+            )
 
         # Refill pipeline to maintain MAX_INFLIGHT
         try:
@@ -211,7 +231,7 @@ def process_s3_bucket():
     logger.info(f"Successfully processed: {success_count} files")
     logger.info(f"Total rows tagged: {total_rows_processed}")
     logger.info(f"Failures encountered: {len(failures)}")
-    
+
     if failures:
         # Save failures to a separate file for targeted retry
         failure_log = "failed_files.txt"
@@ -221,6 +241,7 @@ def process_s3_bucket():
         logger.info(f"Full failure list saved to: {failure_log}")
 
     ray.shutdown()
+
 
 if __name__ == "__main__":
     process_s3_bucket()

--- a/experiments/2_curirculum_architects/tests/test_csv_output.py
+++ b/experiments/2_curirculum_architects/tests/test_csv_output.py
@@ -1,0 +1,160 @@
+"""Tests for CSV output (flat main + rejected log)."""
+
+import csv
+import tempfile
+from pathlib import Path
+
+from curriculum_tags.output import (
+    MAIN_CSV_COLUMNS,
+    REJECTED_CSV_COLUMNS,
+    SCHEMA_VERSION,
+    RejectionReason,
+    is_rejected,
+    write_csv_output,
+)
+from curriculum_tags.output.csv_writer import build_rejected_row, compute_checksum, flatten_record
+
+
+def test_compute_checksum():
+    assert compute_checksum("hello") == compute_checksum("hello")
+    assert compute_checksum("hello") != compute_checksum("world")
+    assert compute_checksum("") != ""
+    assert compute_checksum("  hello  ") == compute_checksum("hello")
+
+
+def test_is_rejected():
+    assert is_rejected({"curriculum_tags": {"error": "fail"}}) is True
+    assert is_rejected({"curriculum_tags": {"band_assignment": {}}}) is True
+    assert is_rejected({"curriculum_tags": {"band_assignment": {"band": ""}}}) is True
+    assert is_rejected({"curriculum_tags": {"band_assignment": {"band": "B1"}}}) is False
+    assert is_rejected({"curriculum_tags": {}}) is True
+
+
+def test_flatten_record():
+    record = {
+        "id": "sample_0",
+        "text": "Hello world.",
+        "curriculum_tags": {
+            "version": "v1",
+            "band_assignment": {"band": "B1", "reason": "constraint_match"},
+            "difficulty": {"level": "L1", "score": 0.25},
+            "readability": {"flesch_kincaid_grade": 5.2},
+            "modality": {"primary_modality": "text"},
+            "tokenizer_difficulty": {"level": "T1"},
+            "entropy": {"score": 3.8},
+            "structural_density": {"structural_density": 0.02},
+            "cot_scanner": {"has_cot": False, "has_agentic": False},
+        },
+    }
+    row = flatten_record(record, "path/to/file.parquet")
+    assert row["id"] == "sample_0"
+    assert row["file_path"] == "path/to/file.parquet"
+    assert row["band"] == "B1"
+    assert row["band_reason"] == "constraint_match"
+    assert row["difficulty_level"] == "L1"
+    assert row["difficulty_score"] == "0.25"
+    assert row["readability_fk_grade"] == "5.2"
+    assert row["primary_modality"] == "text"
+    assert row["tokenizer_level"] == "T1"
+    assert row["entropy_score"] == "3.8"
+    assert row["structural_density"] == "0.02"
+    assert row["has_cot"] == "false"
+    assert row["has_agentic"] == "false"
+    assert row["schema_version"] == SCHEMA_VERSION
+    assert len(row["uuid"]) == 36
+    assert len(row["checksum"]) == 64  # SHA-256 hex
+    assert row["minhash"] == ""
+    assert row["optional_1"] == ""
+
+
+def test_build_rejected_row():
+    record = {"id": "sample_42", "text": "x"}
+    row = build_rejected_row(
+        record,
+        "s3://bucket/part.parquet",
+        RejectionReason.METRIC_FAILED.value,
+        "tokenizer not found",
+    )
+    assert row["id"] == "sample_42"
+    assert row["file_path"] == "s3://bucket/part.parquet"
+    assert row["reason"] == RejectionReason.METRIC_FAILED.value
+    assert row["details"] == "tokenizer not found"
+    assert row["schema_version"] == SCHEMA_VERSION
+    assert len(row["uuid"]) == 36
+
+
+def test_write_csv_output():
+    tagged_ok = {
+        "id": "ok_1",
+        "text": "Hello.",
+        "curriculum_tags": {
+            "version": "v1",
+            "band_assignment": {"band": "B0", "reason": "ok"},
+            "difficulty": {"level": "L0", "score": 0.1},
+            "readability": {},
+            "modality": {"primary_modality": "text"},
+            "tokenizer_difficulty": {},
+            "entropy": {},
+            "structural_density": {},
+            "cot_scanner": {"has_cot": False, "has_agentic": False},
+        },
+    }
+    tagged_rejected = {
+        "id": "bad_1",
+        "text": "x",
+        "curriculum_tags": {"version": "v1", "error": "metric failed"},
+    }
+    with tempfile.TemporaryDirectory() as tmpdir:
+        main_path = Path(tmpdir) / "main.csv"
+        stats = write_csv_output(
+            [tagged_ok, tagged_rejected],
+            file_path="input.parquet",
+            output_csv_path=main_path,
+        )
+        assert stats["main_row_count"] == 1
+        assert stats["rejected_row_count"] == 1
+        assert Path(stats["main_csv_path"]).exists()
+        assert Path(stats["rejected_csv_path"]).exists()
+
+        with open(main_path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["id"] == "ok_1"
+        assert rows[0]["band"] == "B0"
+        assert rows[0]["file_path"] == "input.parquet"
+        assert list(rows[0].keys()) == MAIN_CSV_COLUMNS
+
+        rejected_path = Path(tmpdir) / "main_rejected.csv"
+        with open(rejected_path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rej_rows = list(reader)
+        assert len(rej_rows) == 1
+        assert rej_rows[0]["id"] == "bad_1"
+        assert rej_rows[0]["reason"] == RejectionReason.METRIC_FAILED.value
+        assert list(rej_rows[0].keys()) == REJECTED_CSV_COLUMNS
+
+
+def test_write_csv_output_custom_rejected_path():
+    tagged_ok = {
+        "id": "ok",
+        "text": "Hi",
+        "curriculum_tags": {
+            "version": "v1",
+            "band_assignment": {"band": "B1", "reason": ""},
+        },
+    }
+    with tempfile.TemporaryDirectory() as tmpdir:
+        main_path = Path(tmpdir) / "out.csv"
+        rejected_path = Path(tmpdir) / "rejected_only.csv"
+        write_csv_output(
+            [tagged_ok],
+            file_path="x.parquet",
+            output_csv_path=main_path,
+            rejected_csv_path=rejected_path,
+        )
+        assert main_path.exists()
+        assert rejected_path.exists()
+        with open(rejected_path, newline="", encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+        assert len(rows) == 0

--- a/experiments/2_curirculum_architects/tests/test_tagger.py
+++ b/experiments/2_curirculum_architects/tests/test_tagger.py
@@ -144,8 +144,33 @@ def test_plugin_chaining(temp_curriculum):
     assert tagged["curriculum_tags"]["second"]["doubled"] == 84
 
 
-def test_process_parquet(temp_curriculum, temp_parquet):
-    """Test processing parquet file."""
+def test_process_parquet_csv_only(temp_curriculum, temp_parquet):
+    """Test processing parquet with CSV output only (default: no Parquet)."""
+    config = CurriculumConfig(temp_curriculum)
+    plugins = [SimpleMetric(config)]
+
+    tagger = CurriculumTagger(temp_curriculum, metrics=plugins)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_csv = Path(tmpdir) / "output.csv"
+        stats = tagger.process_parquet(
+            temp_parquet,
+            output_csv_path=output_csv,
+            write_parquet=False,
+        )
+
+        assert stats["total_rows"] == 2
+        assert stats["error_count"] == 0
+        assert "output_file" not in stats
+        assert stats["main_csv_path"] == str(output_csv)
+        assert output_csv.exists()
+        assert Path(stats["rejected_csv_path"]).exists()
+        # SimpleMetric has no band_assignment, so rows go to rejected; main + rejected = 2
+        assert stats["main_csv_rows"] + stats["rejected_csv_rows"] == 2
+
+
+def test_process_parquet_with_pass_through_parquet(temp_curriculum, temp_parquet):
+    """Test write_parquet=True: pass-through Parquet (no curriculum_tags), no metadata Parquet."""
     config = CurriculumConfig(temp_curriculum)
     plugins = [SimpleMetric(config)]
 
@@ -155,25 +180,31 @@ def test_process_parquet(temp_curriculum, temp_parquet):
         output_path = Path(f.name)
 
     try:
-        stats = tagger.process_parquet(temp_parquet, output_path)
+        stats = tagger.process_parquet(
+            temp_parquet,
+            output_path=output_path,
+            write_parquet=True,
+        )
 
         assert stats["total_rows"] == 2
         assert stats["error_count"] == 0
-        assert Path(stats["output_file"]).exists()
+        assert stats["output_file"] == str(output_path)
+        assert "metadata_file" not in stats
 
-        # Verify output
         result_table = pq.read_table(output_path)
         result_data = result_table.to_pylist()
 
         assert len(result_data) == 2
-        assert all("curriculum_tags" in row for row in result_data)
+        # Pass-through: no curriculum_tags column
+        assert all("curriculum_tags" not in row for row in result_data)
+        assert all(row["id"] in ("1", "2") and "text" in row for row in result_data)
 
     finally:
-        output_path.unlink()
+        output_path.unlink(missing_ok=True)
 
 
 def test_process_parquet_with_errors(temp_curriculum, temp_parquet):
-    """Test handling errors during processing."""
+    """Test handling errors during processing; pass-through Parquet has no tags."""
 
     class ErrorMetric(MetricPlugin):
         name = "error_metric"
@@ -186,21 +217,25 @@ def test_process_parquet_with_errors(temp_curriculum, temp_parquet):
 
     tagger = CurriculumTagger(temp_curriculum, metrics=plugins)
 
-    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
-        output_path = Path(f.name)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "out.parquet"
+        output_csv = Path(tmpdir) / "out.csv"
+        stats = tagger.process_parquet(
+            temp_parquet,
+            output_path=output_path,
+            output_csv_path=output_csv,
+            write_parquet=True,
+        )
 
-    try:
-        stats = tagger.process_parquet(temp_parquet, output_path)
-
-        # Should process but record errors
         assert stats["total_rows"] == 2
-        # Errors are caught and stored in tags
+        # Tagger catches plugin errors and stores in tags; error_count only for tag_sample re-raise
+        assert stats["error_count"] == 0
         result_table = pq.read_table(output_path)
         result_data = result_table.to_pylist()
-        assert all("error" in row["curriculum_tags"]["error_metric"] for row in result_data)
-
-    finally:
-        output_path.unlink()
+        # Pass-through Parquet: no curriculum_tags column
+        assert all("curriculum_tags" not in row for row in result_data)
+        # Rejected CSV: both rows have curriculum_tags.error (metric failed), so both rejected
+        assert stats.get("rejected_csv_rows", 0) == 2
 
 
 def test_process_nonexistent_file(temp_curriculum):
@@ -208,4 +243,4 @@ def test_process_nonexistent_file(temp_curriculum):
     tagger = CurriculumTagger(temp_curriculum, metrics=[])
 
     with pytest.raises(FileNotFoundError):
-        tagger.process_parquet("nonexistent.parquet", "output.parquet")
+        tagger.process_parquet("nonexistent.parquet")


### PR DESCRIPTION
[output_rejected.csv](https://github.com/user-attachments/files/25031327/output_rejected.csv)
[output.csv](https://github.com/user-attachments/files/25031328/output.csv)
# Pull Request Template

## Description

Please include a summary of the changes and the related issue. Highlight any key points that reviewers should focus on.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if applicable).
- [x] My code follows the style guidelines, gitflow branching strategy, and naming conventions of this project [Contribution Guidelines](<https://github.com/The-School-of-AI/LLM/tree/main/experiments/>

## Reviewers

- [x] **Reviewer 1**: A member from your own team.
- [x] **Reviewer 2**: A member from the repo owners team (@The-School-of-AI/llm-repo-owners).

> **Note**: Every pull request requires atleast 2 reviewers/approvers before it can be merged.

fixes #308 

Summary of changes
1. Schema spec
OUTPUT_SCHEMA.md — Defines main CSV columns (uuid, id, file_path, band, other tags, checksum, minhash, optional_1–3, schema_version), rejected-log columns (uuid, id, file_path, reason, details, schema_version), and rejection reasons.
2. Output package
curriculum_tags/output/__init__.py — Exposes schema and writer.
curriculum_tags/output/schema.py — MAIN_CSV_COLUMNS, REJECTED_CSV_COLUMNS, SCHEMA_VERSION, RejectionReason enum.
curriculum_tags/output/csv_writer.py —
compute_checksum(text) — SHA-256 of normalized text.
is_rejected(record) — True if curriculum_tags.error or band missing.
flatten_record(record, file_path) — One flat main-CSV row from nested tags.
build_rejected_row(record, file_path, reason, details) — One rejected-log row.
write_csv_output(tagged_records, file_path, output_csv_path, rejected_csv_path=None) — Writes main CSV and rejected CSV (rejected path default: {stem}_rejected.csv).
3. Tagger integration
curriculum_tags/core/tagger.py
process_parquet(..., output_csv_path=None) — When output_csv_path is set, accumulates all tagged records with file_path = str(input_path), then calls write_csv_output after writing Parquet. Returns main_csv_path, rejected_csv_path, main_csv_rows, rejected_csv_rows when CSV is written.
process_parquet_s3(..., output_csv_path=None) — Same behavior; CSV is written to the given local path (e.g. for S3 workers, pass a local path to collect CSV).
Removed per-sample debug print in tag_sample.
4. Example
examples/parquet_processing.py — Passes output_csv_path=Path(CSV_OUTPUT_PATH) / "output.csv" and prints main/rejected CSV paths and row counts.
5. Tests
tests/test_csv_output.py — Tests for compute_checksum, is_rejected, flatten_record, build_rejected_row, write_csv_output (default and custom rejected path). All 6 tests pass.
6. Docs
README.md — Output description updated to mention optional flat CSV; step 6 and link to OUTPUT_SCHEMA.md; Quick Reference table includes OUTPUT_SCHEMA.md.
Output after changes
Parquet: Unchanged (full row + nested curriculum_tags + metadata Parquet).
Main CSV (when output_csv_path is set): Flat columns per OUTPUT_SCHEMA.md; one row per successfully tagged record; file_path = input Parquet path; checksum = SHA-256 of normalized text; minhash and optional_1–3 reserved/empty.
Rejected CSV: One row per rejected record (error or missing band); columns uuid, id, file_path, reason, details, schema_version.

Output description: CSV only by default; optional pass-through Parquet when write_parquet=True; 