### PR TITLE
fix(flops-calc): Parameter bugs, config parsing, KPE/mHC docs, and DeltaNet support

### DIFF
--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/README.md
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/README.md
@@ -750,6 +750,47 @@ YaRN (Yet another RoPE extensioN) has **zero computational overhead** compared t
 The cost of training at longer contexts is automatically captured via `sequence_length` in the O(S²) attention formula.
 No additional configuration is needed for YaRN FLOPs accounting.
 
+#### DeltaNet (Gated Linear Attention)
+DeltaNet is a linear attention mechanism with **O(S × d²)** complexity instead of O(S² × d) for standard attention.
+This makes it dramatically more efficient for long sequences (256k+ tokens).
+
+**Standalone usage:**
+```json
+{
+  "attention_type": "deltanet"
+}
+```
+Aliases: `deltanet`, `delta`, `linear`, `gated_linear`, `gated_deltanet`
+
+**Hybrid DeltaNet-GSA format:**
+```json
+{
+  "attention_type": "deltanet-gsa:3:1:512"
+}
+```
+- `3:1` = 75% DeltaNet layers, 25% GSA layers
+- `512` = GSA sparse k tokens
+
+**Complexity comparison:**
+| Attention Type | Complexity | 256k Context (d=128) |
+|---------------|------------|----------------------|
+| Dense | O(S² × d) | Very expensive |
+| GSA | O(S × k) + O(S²_indexer) | Fast |
+| **DeltaNet** | **O(S × d²)** | **Fastest at long seq** |
+
+Crossover: When S > d², DeltaNet wins. For head_dim=128, crossover at ~16k tokens.
+
+**DeltaNet config options:**
+```json
+{
+  "deltanet": {
+    "num_heads": 32,
+    "head_dim": 128,
+    "conv_size": 4
+  }
+}
+```
+
 ### 3. Cost Calculation
 ```python
 Cost = (Total_FLOPs / Effective_Cluster_PFLOPS) * Price_Per_GPU_Hour * Num_GPUs

--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/README.md
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/README.md
@@ -745,16 +745,10 @@ Set `attention_type: deepseek_mla` and provide either:
 - `ds_compressed_dim` (alias)
 to model KV compression in attention FLOPs.
 
-#### YaRN (Position) Overhead
-If you are using YaRN from the start and want to model any extra overhead beyond
-sequence length, set:
-```json
-"position": {
-  "position_type": "yarn",
-  "yarn_flops_multiplier": 1.0
-}
-```
-`yarn_flops_multiplier` scales the **attention** FLOPs term when `position_type` is `yarn`.
+#### YaRN Position Encoding
+YaRN (Yet another RoPE extensioN) has **zero computational overhead** compared to standard RoPE.
+The cost of training at longer contexts is automatically captured via `sequence_length` in the O(S²) attention formula.
+No additional configuration is needed for YaRN FLOPs accounting.
 
 ### 3. Cost Calculation
 ```python

--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/README.md
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/README.md
@@ -791,7 +791,104 @@ Crossover: When S > d², DeltaNet wins. For head_dim=128, crossover at ~16k toke
 }
 ```
 
+#### Kronecker Product Embeddings (KPE)
+
+Instead of a standard `vocab × hidden` lookup table, KPE represents each token as a fixed Kronecker product of character-level and position-level factors, followed by a trainable projection.
+
+**Standard embeddings:** `vocab × hidden` params (e.g., 131072 × 4096 = **537M params**)
+**Kronecker embeddings:** `D × hidden + hidden` params (e.g., 8192 × 4096 + 4096 = **33.6M params** — **16× smaller**)
+
+**Configuration:**
+```json
+{
+  "embedding_type": "kronecker",
+  "kronecker_config": {
+    "char_dim": 256,       // Character embedding dimension
+    "pos_dim": 32,         // Position embedding dimension
+    "D": 8192              // Product feature dimension (char_dim × pos_dim)
+  },
+  "tie_embeddings": false  // KPE cannot be tied (forced to false)
+}
+```
+
+**Parameters:**
+| Component | Formula | Example (D=8192, H=4096) |
+|-----------|---------|--------------------------|
+| `pf_to_model` | D × H | 33,554,432 |
+| `embed_norm` (RMSNorm) | H | 4,096 |
+| **Total** | **D × H + H** | **33.6M** |
+
+**FLOPs:** Unlike standard lookup (negligible FLOPs), KPE adds a matrix multiply per token:
+```
+FLOPs = 6 × seq_len × D × hidden  (fwd + bwd-grad + bwd-weight)
+```
+
+> **Note:** KPE forces `tie_embeddings: false` since the embedding and LM head have different dimensions.
+
+#### Multi-Head Composition (mHC)
+
+mHC enables **reversible** multi-stream architectures. The hidden state is split into `n_streams` parallel streams, and each sublayer (attention/FFN) uses learnable mixing coefficients to combine streams before and after processing.
+
+**Key benefit:** With reversibility, activations can be **reconstructed from outputs** during backward pass, reducing activation memory from O(layers) to O(1). This is separate from gradient checkpointing.
+
+**Configuration:**
+```json
+{
+  "n_streams": 4    // Number of parallel streams (typically 4)
+}
+```
+
+**Parameters per sublayer** (2 sublayers per layer: attention + FFN):
+| Component | Formula | Example (H=4096, S=4) |
+|-----------|---------|------------------------|
+| φ_pre (pre-mixing) | S×H × S | 65,536 |
+| φ_post (post-mixing) | S×H × S | 65,536 |
+| φ_res (residual mixing) | S×H × S² | 262,144 |
+| Biases | S + S + S² | 24 |
+| Alphas | 3 | 3 |
+| RMSNorm | S × H | 16,384 |
+| **Per sublayer** | | **409,627** |
+| **Per layer** (×2) | | **819,254** |
+
+Where `S = n_streams` and `d_in = S × hidden`.
+
+**Total mHC params** = `layers × 2 × mhc_per_sublayer` (included in both total and active params).
+
+
+
+
+#### MoE Upcycling Cost Calculation
+
+When converting a Dense model to MoE, you need to shrink FFN weights to create experts. The calculator supports three upcycling methods:
+
+| Method | FLOPs | Description |
+|--------|-------|-------------|
+| `slicing` | 0 | Memory copy only (take first N columns) |
+| `random_projection` | O(H × src × tgt) | Project via random matrix |
+| `svd` | O(min² × max) | Truncated SVD decomposition |
+
+**Usage:**
+```bash
+# Upcycling comparison only (clean output)
+python3 compute.py --config configs/moe_team8/test_upcycling_methods.json --upcycling-only
+```
+
+**Configuration:**
+```json
+{
+  "upcycling": {
+    "method": "svd",
+    "source_intermediate_size": 4096,
+    "target_intermediate_size": 1024,
+    "num_experts_to_create": 20
+  }
+}
+```
+
+**Trade-offs:** Slicing is fastest but may lose info. Random projection is balanced. SVD is slowest but preserves max variance.
+
 ### 3. Cost Calculation
+
 ```python
 Cost = (Total_FLOPs / Effective_Cluster_PFLOPS) * Price_Per_GPU_Hour * Num_GPUs
 ```

--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/compute.py
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/compute.py
@@ -288,7 +288,33 @@ class TrainingStage:
         if num_moe_layers < 0 or num_moe_layers > layers:
             raise ValueError("num_moe_layers must be between 0 and num_layers.")
 
-        embedding_params = vocab * hidden
+
+        # Embedding parameter calculation
+        # Support both standard and Kronecker Product Embeddings
+        embedding_type = arch.get("embedding_type", "standard")
+        
+        if embedding_type == "kronecker":
+            # Kronecker Product Embeddings
+            # Fixed encoding (no trainable params) + trainable projection
+            kronecker_cfg = arch.get("kronecker_config", {})
+            D = kronecker_cfg.get("D", 8192)  # Default: 256 bytes × 32 positions
+            
+            # Trainable parameters:
+            # 1. pf_to_model: Linear(D, hidden, bias=False)
+            pf_to_model_params = D * hidden
+            
+            # 2. embed_norm: RMSNorm(hidden) 
+            embed_norm_params = hidden
+            
+            embedding_params = pf_to_model_params + embed_norm_params
+            
+            # Kronecker embeddings cannot be tied (different dimensions)
+            # Force untied to ensure lm_head is counted
+            tie_embeddings = False
+        else:
+            # Standard embeddings: vocab × hidden lookup table
+            embedding_params = vocab * hidden
+
         lm_head_multiplier = arch.get(
             "lm_head_multiplier", head_cfg.get("lm_head_multiplier")
         )
@@ -346,7 +372,10 @@ class TrainingStage:
         )
         if use_sparse_attn and indexer_heads and indexer_dim:
             indexer_params = (
-                hidden * indexer_heads * indexer_dim * 2 + hidden * indexer_heads
+                hidden * indexer_heads * indexer_dim  # W_Iq: H -> ih*id
+                + hidden * indexer_dim                # W_Ik: H -> id
+                + hidden * indexer_heads              # W_Iw: H -> ih
+                + indexer_heads                       # gate_bias
             )
             attn_params_per_layer += indexer_params
 
@@ -360,9 +389,27 @@ class TrainingStage:
                 attention_cfg.get("gsa_use_output_gate", True),
             )
             if use_value_gate:
-                attn_params_per_layer += hidden * hidden * kv_ratio
+                attn_params_per_layer += hidden * hidden  # W_gv: full H*H (not kv_ratio)
             if use_output_gate:
                 attn_params_per_layer += hidden * hidden
+
+        # Calculate GSA-specific attention params (for hybrid layer separation)
+        # GSA uses: Q, K, V, O projections + dual gating (value gate + output gate) + indexer
+        gsa_attn_params_per_layer = 4 * hidden * hidden  # Q, K, V, O
+        if gsa_enabled:
+            if use_value_gate:
+                gsa_attn_params_per_layer += hidden * hidden  # W_gv: full H*H
+            if use_output_gate:
+                gsa_attn_params_per_layer += hidden * hidden  # W_go
+            # GSA indexer params
+            if indexer_heads and indexer_dim:
+                gsa_indexer_params = (
+                    hidden * indexer_heads * indexer_dim  # W_Iq
+                    + hidden * indexer_dim                # W_Ik
+                    + hidden * indexer_heads              # W_Iw
+                    + indexer_heads                       # gate_bias
+                )
+                gsa_attn_params_per_layer += gsa_indexer_params
 
         attn_params_per_layer += float(
             arch.get(
@@ -405,8 +452,15 @@ class TrainingStage:
         elif deltanet_enabled and not deltanet_in_hybrid:
             deltanet_layer_weight = 1.0
         
-        num_deltanet_layers = int(layers * deltanet_layer_weight)
-        num_gsa_layers_hybrid = int(layers * gsa_layer_weight) if deltanet_in_hybrid else 0
+        # Read explicit layer counts from config first, then fall back to weight calculation
+        num_deltanet_layers = deltanet_cfg.get(
+            "num_deltanet_layers", 
+            arch.get("num_deltanet_layers", int(layers * deltanet_layer_weight))
+        )
+        num_gsa_layers_hybrid = deltanet_cfg.get(
+            "num_gsa_layers",
+            arch.get("num_gsa_layers", int(layers * gsa_layer_weight) if deltanet_in_hybrid else 0)
+        )
         
         # DeltaNet-specific parameters per layer
         deltanet_extra_params_per_layer = 0
@@ -419,6 +473,8 @@ class TrainingStage:
             a_log_params = delta_num_heads
             # D: per-head residual parameter
             d_params = delta_num_heads
+            # dt_bias: per-head bias for delta gate
+            dt_bias_params = delta_num_heads
             # Short convolutions on Q/K/V (depthwise, kernel=conv_size)
             short_conv_params = 3 * hidden * delta_conv_size
             # Output norm weight (per head_dim)
@@ -426,7 +482,7 @@ class TrainingStage:
             
             deltanet_extra_params_per_layer = (
                 beta_gate_params + alpha_gate_params + a_log_params + 
-                d_params + short_conv_params + o_norm_params
+                d_params + dt_bias_params + short_conv_params + o_norm_params
             )
             
             # DeltaNet uses 5 projections: Q, K, V, G (output gate), O
@@ -441,15 +497,31 @@ class TrainingStage:
         ffn_params_dense = 3 * hidden * intermediate
         ffn_params_per_expert = 3 * hidden * moe_intermediate
 
+        # Shared expert uses its own intermediate size (may differ from routed experts)
+        shared_expert_intermediate = arch.get(
+            "shared_expert_intermediate_size",
+            expert_cfg.get("shared_expert_intermediate_size", moe_intermediate)
+        )
+        ffn_params_per_shared_expert = 3 * hidden * shared_expert_intermediate
+
         total_ffn_params_moe = 0
         active_ffn_params_moe = 0
         router_params = 0
-        shared_expert_params = num_shared_experts * ffn_params_per_expert
+        shared_expert_params = num_shared_experts * ffn_params_per_shared_expert
         null_expert_params_per_expert = arch.get(
             "null_expert_params_per_expert",
             router_cfg.get("null_expert_params_per_expert", 0),
         )
         null_expert_params = num_null_experts * null_expert_params_per_expert
+        
+        # Data sparsity affects active expert count (e.g. 0.5 = half tokens go to null experts)
+        data_sparsity = arch.get(
+            "data_sparsity", 
+            router_cfg.get("data_sparsity", 1.0)  # Default 1.0 = no null routing
+        )
+        # Effective active experts: top_k * data_sparsity
+        e_k_real = top_k * data_sparsity
+        
         router_type = str(router_cfg.get("router_type", "")).strip().lower()
         if (
             experts > 0
@@ -483,7 +555,7 @@ class TrainingStage:
                 + null_expert_params
             )
             active_ffn_params_moe = (
-                top_k * ffn_params_per_expert + shared_expert_params + router_params
+                e_k_real * ffn_params_per_expert + shared_expert_params + router_params
             )
 
         dense_layers = layers - num_moe_layers
@@ -528,7 +600,7 @@ class TrainingStage:
                 + null_expert_params
             )
             active_ffn_params_moe = (
-                top_k * ffn_params_per_expert + shared_expert_params + router_params
+                e_k_real * ffn_params_per_expert + shared_expert_params + router_params
             )
             num_moe_layers = layers if num_moe_layers == 0 else num_moe_layers
         elif solve_for == "num_experts_from_per_expert":
@@ -551,7 +623,7 @@ class TrainingStage:
                 + null_expert_params
             )
             active_ffn_params_moe = (
-                top_k * ffn_params_per_expert + shared_expert_params + router_params
+                e_k_real * ffn_params_per_expert + shared_expert_params + router_params
             )
             derived_experts = experts
 
@@ -571,31 +643,103 @@ class TrainingStage:
         else:
             norm_params = num_norms * 2 * hidden  # gamma + beta
 
+        # =========================================================================
+        # mHC (Multi-Head Composition) Parameters
+        # Used in reversible/stream-based architectures (e.g., LightningLM)
+        # Each layer has 2 mHC sublayers (attn + mlp blocks)
+        # =========================================================================
+        mhc_cfg = arch.get("mhc", {})
+        n_streams = mhc_cfg.get("n_streams", arch.get("n_streams", 0))
+        mhc_params_per_layer = 0
+        if n_streams > 0:
+            d_in = n_streams * hidden
+            # MHCCoeffs per sublayer
+            mhc_phi_pre = d_in * n_streams
+            mhc_phi_post = d_in * n_streams
+            mhc_phi_res = d_in * (n_streams * n_streams)
+            mhc_biases = n_streams + n_streams + (n_streams * n_streams)
+            mhc_alphas = 3  # alpha_pre, alpha_post, alpha_res
+            mhc_rms = d_in  # RMSNorm per sublayer
+            mhc_per_sublayer = mhc_phi_pre + mhc_phi_post + mhc_phi_res + mhc_biases + mhc_alphas + mhc_rms
+            mhc_params_per_layer = 2 * mhc_per_sublayer  # 2 sublayers: attn + mlp
+
+        total_mhc_params = layers * mhc_params_per_layer
+
+        # =========================================================================
+        # MTP Block Parameters (Multi-Token Prediction)
+        # MTP block contains: fusion projection + DeltaNet layer + FFN/MoE + mHC + norms
+        # This is a full transformer layer plus fusion projection
+        # =========================================================================
+        mtp_cfg = arch.get("mtp", head_cfg)
+        mtp_enabled = mtp_cfg.get("enabled", use_mtp)
+        mtp_num_predictions = mtp_cfg.get("num_predictions", head_cfg.get("mtp_heads", 2)) if mtp_enabled else 0
+        # Calculate attention params per layer type for hybrid models
+        # DeltaNet layers: base attention (4*H*H) + G projection + extra params (gates, convs)
+        # GSA layers: base attention (4*H*H) + dual gating (W_gv, W_go) + indexer
+        base_attn_params = 4 * hidden * hidden
+        deltanet_attn_per_layer = base_attn_params + deltanet_extra_params_per_layer
+        gsa_attn_per_layer = gsa_attn_params_per_layer if gsa_enabled else base_attn_params
+
+        mtp_block_params = 0
+        mtp_block_active_params = 0
+        if mtp_enabled and mtp_num_predictions > 0:
+            # Fusion projection: (d * 2) * d (combines current and previous hidden states)
+            mtp_fusion_params = (hidden * 2) * hidden
+            # DeltaNet layer (same as regular DeltaNet layer)
+            mtp_deltanet_params = deltanet_attn_per_layer
+            # FFN layer (MoE or dense)
+            mtp_ffn_total = total_ffn_params_moe if num_moe_layers > 0 else ffn_params_dense
+            mtp_ffn_active = active_ffn_params_moe if num_moe_layers > 0 else ffn_params_dense
+            # mHC (same as regular layer)
+            mtp_mhc_params = mhc_params_per_layer
+            # Norms (2 per layer)
+            mtp_norms = 2 * hidden
+            
+            mtp_block_params = mtp_fusion_params + mtp_deltanet_params + mtp_ffn_total + mtp_mhc_params + mtp_norms
+            mtp_block_active_params = mtp_fusion_params + mtp_deltanet_params + mtp_ffn_active + mtp_mhc_params + mtp_norms
+        
+        # Number of GSA layers in hybrid mode
+        num_gsa_layers_in_model = num_gsa_layers_hybrid if deltanet_in_hybrid else (
+            layers if gsa_enabled and not deltanet_enabled else 0
+        )
+        # Number of pure standard attention layers (neither DeltaNet nor GSA)
+        num_std_attn_layers = layers - num_deltanet_layers - num_gsa_layers_in_model
+        
+        # Total attention params across all layers
+        total_attn_params = (
+            num_deltanet_layers * deltanet_attn_per_layer +
+            num_gsa_layers_in_model * gsa_attn_per_layer +
+            num_std_attn_layers * base_attn_params
+        )
+
         total_params = (
             embedding_params
             + lm_head_params
-            + layers * attn_params_per_layer
-            + num_deltanet_layers * deltanet_extra_params_per_layer  # DeltaNet-specific params
+            + total_attn_params  # Layer-type-specific attention params
             + dense_layers * ffn_params_dense
             + num_moe_layers * total_ffn_params_moe
             + norm_params
+            + total_mhc_params  # mHC params
+            + mtp_block_params  # MTP block (full layer + fusion)
         )
 
         active_non_embed_params = (
-            layers * attn_params_per_layer
-            + num_deltanet_layers * deltanet_extra_params_per_layer  # DeltaNet-specific params
+            total_attn_params  # Layer-type-specific attention params
             + dense_layers * ffn_params_dense
             + num_moe_layers * active_ffn_params_moe
             + lm_head_params
             + norm_params
+            + total_mhc_params  # mHC params
+            + mtp_block_active_params  # MTP block active params
         )
         active_linear_params = (
-            layers * attn_params_per_layer
-            + num_deltanet_layers * deltanet_extra_params_per_layer  # DeltaNet-specific params
+            total_attn_params  # Layer-type-specific attention params
             + dense_layers * ffn_params_dense
             + num_moe_layers * active_ffn_params_moe
             + lm_head_params_for_flops
             + norm_params
+            + total_mhc_params  # mHC params
+            + mtp_block_active_params  # MTP block active params
         )
         active_params_base = embedding_params + active_non_embed_params
 
@@ -637,9 +781,12 @@ class TrainingStage:
 
         return {
             "total_params": total_params,
-            "active_params": effective_active_params,
-            "active_non_embed_params": effective_active_non_embed_params,
-            "active_linear_params": effective_active_linear_params,
+            "active_params": active_params_base,
+            "active_non_embed_params": active_non_embed_params,
+            "active_linear_params": active_linear_params,
+            "effective_active_params": effective_active_params,
+            "effective_active_non_embed_params": effective_active_non_embed_params,
+            "effective_active_linear_params": effective_active_linear_params,
             "embedding_params": embedding_params,
             "lm_head_params": lm_head_params,
             "num_moe_layers": num_moe_layers,
@@ -1273,9 +1420,31 @@ class TrainingStage:
         flops_per_seq_norm = num_norms * norm_flops_per_instance * norm_training_mult
 
         # =========================================================================
+        # Embedding FLOPs (Kronecker Product Embeddings only)
+        # =========================================================================
+        # Standard embeddings: Lookup operation (negligible FLOPs)
+        # Kronecker embeddings: Matrix multiplication per token
+        #   - Forward: s × (D × hidden) = s × D × h
+        #   - Backward (gradients): s × (D × hidden) = s × D × h  
+        #   - Backward (weight): s × (D × hidden) = s × D × h
+        #   - Total: 6 × s × D × h (with recompute overhead)
+        # =========================================================================
+        flops_per_seq_embedding = 0
+        embedding_type = arch.get("embedding_type", "standard")
+        
+        if embedding_type == "kronecker":
+            kronecker_cfg = arch.get("kronecker_config", {})
+            D = kronecker_cfg.get("D", 8192)
+            
+            # Matmul FLOPs: forward (2x) + backward-grad (2x) + backward-weight (2x) = 6x
+            # Each matmul: s tokens × D × h
+            flops_per_seq_embedding = 6 * s * D * h * recompute_multiplier
+        
+        # =========================================================================
         # Total FLOPs
         # =========================================================================
         flops_per_seq_total = (
+            flops_per_seq_embedding +
             flops_per_seq_linear + 
             flops_per_seq_attn + 
             flops_per_seq_router + 
@@ -1293,6 +1462,140 @@ class TrainingStage:
             raise ValueError("total_tokens must be > 0.")
 
         return self.flops_per_token(params) * self.total_tokens
+
+    def calculate_upcycling_flops(self, params: Optional[dict] = None) -> dict:
+        """
+        Calculate one-time FLOPs for Dense→MoE upcycling.
+        
+        This is a one-time cost when converting a dense model checkpoint to MoE,
+        not a per-training cost.
+        
+        Upcycling methods:
+        - slicing: Zero FLOPs (just memory copy, take first N columns)
+        - random_projection: O(H × src × tgt) matmul per weight matrix
+        - svd: O(min² × max) per weight matrix (truncated SVD)
+        
+        Returns:
+            dict with upcycling_flops, method, and breakdown
+        """
+        params = params or self.calculate_params()
+        arch = self.architecture
+        
+        # Get upcycling config
+        upcycling_cfg = arch.get("upcycling", {})
+        method = upcycling_cfg.get("method", "none")
+        
+        if method == "none" or not upcycling_cfg:
+            return {
+                "method": "none",
+                "upcycling_flops": 0,
+                "upcycling_time_seconds": 0,
+                "breakdown": {}
+            }
+        
+        # Source and target dimensions
+        hidden = arch.get("hidden_size", 4096)
+        source_intermediate = upcycling_cfg.get(
+            "source_intermediate_size", 
+            arch.get("intermediate_size", arch.get("ffn_intermediate_size", hidden * 4))
+        )
+        target_intermediate = upcycling_cfg.get(
+            "target_intermediate_size",
+            arch.get("moe_intermediate_size", arch.get("expert_intermediate_size", 1024))
+        )
+        num_experts = upcycling_cfg.get(
+            "num_experts_to_create",
+            arch.get("num_routed_experts", arch.get("num_real_experts", 1))
+        )
+        layers = arch.get("num_layers", 32)
+        
+        # SwiGLU has 3 weight matrices per FFN: gate_proj, up_proj, down_proj
+        # For upcycling, we need to shrink each matrix
+        num_matrices_per_layer = 3
+        
+        if method == "slicing":
+            # Just memory copy, zero compute FLOPs
+            upcycling_flops = 0
+            breakdown = {
+                "method": "slicing",
+                "description": "Zero compute (memory copy only)",
+                "flops_per_matrix": 0
+            }
+            
+        elif method == "random_projection":
+            # FLOPs = 2 × m × n × k for matrix multiply
+            # For each weight matrix: W_expert = W_dense @ R
+            # gate_proj/up_proj: (H, source) @ (source, target) → 2 × H × source × target
+            # down_proj: (source, H) @ (source, target) → project rows
+            flops_per_up_proj = 2 * hidden * source_intermediate * target_intermediate
+            flops_per_down_proj = 2 * source_intermediate * hidden * target_intermediate
+            
+            # Total per expert: 2 up-style + 1 down-style (SwiGLU)
+            flops_per_expert = 2 * flops_per_up_proj + flops_per_down_proj
+            
+            # Total across all layers and experts
+            upcycling_flops = flops_per_expert * num_experts * layers
+            
+            breakdown = {
+                "method": "random_projection",
+                "description": f"Project {source_intermediate}→{target_intermediate} via random matrix",
+                "flops_per_up_proj": flops_per_up_proj,
+                "flops_per_down_proj": flops_per_down_proj,
+                "flops_per_expert": flops_per_expert,
+                "num_experts": num_experts,
+                "num_layers": layers
+            }
+            
+        elif method == "svd":
+            # Truncated SVD: O(min(m,n)² × max(m,n))
+            # For up_proj (H × source): min=H, max=source
+            m_up, n_up = hidden, source_intermediate
+            min_up, max_up = min(m_up, n_up), max(m_up, n_up)
+            svd_flops_up = min_up ** 2 * max_up
+            
+            # For down_proj (source × H): min=H, max=source
+            m_down, n_down = source_intermediate, hidden
+            min_down, max_down = min(m_down, n_down), max(m_down, n_down)
+            svd_flops_down = min_down ** 2 * max_down
+            
+            # Reconstruction: U[:, :k] @ diag(S[:k]) @ Vt[:k, :]
+            # This is much cheaper than SVD itself, so we approximate total as 1.5× SVD
+            reconstruction_multiplier = 1.5
+            
+            # Total per expert: 2 up-style + 1 down-style (SwiGLU)
+            flops_per_expert = (2 * svd_flops_up + svd_flops_down) * reconstruction_multiplier
+            
+            # Total across all layers and experts
+            upcycling_flops = flops_per_expert * num_experts * layers
+            
+            breakdown = {
+                "method": "svd",
+                "description": f"Truncated SVD {source_intermediate}→{target_intermediate}",
+                "svd_flops_up_proj": svd_flops_up,
+                "svd_flops_down_proj": svd_flops_down,
+                "flops_per_expert": flops_per_expert,
+                "num_experts": num_experts,
+                "num_layers": layers
+            }
+        else:
+            # Unknown method
+            upcycling_flops = 0
+            breakdown = {"method": method, "description": "Unknown method"}
+        
+        # Estimate time assuming H100 at 989 TFLOPs (BF16)
+        # Use 50% efficiency for these small operations
+        h100_tflops = 989 * 0.5
+        upcycling_time_seconds = upcycling_flops / (h100_tflops * 1e12) if upcycling_flops > 0 else 0
+        
+        return {
+            "method": method,
+            "upcycling_flops": upcycling_flops,
+            "upcycling_time_seconds": upcycling_time_seconds,
+            "source_intermediate": source_intermediate,
+            "target_intermediate": target_intermediate,
+            "num_experts": num_experts,
+            "breakdown": breakdown
+        }
 
 
 def load_config(config_path: str):
@@ -1341,8 +1644,8 @@ def normalize_deepspeed_config(config: dict) -> dict:
     """
     hardware = config.get("hardware", {}).copy()
 
-    # 1. Parse zero_optimization (DeepSpeed-style)
-    zero_opt = config.get("zero_optimization", {})
+    # 1. Parse zero_optimization (DeepSpeed-style, or nested in hardware)
+    zero_opt = config.get("zero_optimization", hardware.get("zero_optimization", {}))
     if zero_opt:
         # Stage
         if "stage" in zero_opt:
@@ -1372,9 +1675,9 @@ def normalize_deepspeed_config(config: dict) -> dict:
                 "gpu_buffer_gb": zero_opt.get("pin_memory", 4.0),
             }
 
-    # 2. Parse activation_checkpointing (DeepSpeed-style)
+    # 2. Parse activation_checkpointing (DeepSpeed-style, or nested in hardware)
     # Always parse and store settings - activation memory is always calculated now
-    act_ckpt = config.get("activation_checkpointing", {})
+    act_ckpt = config.get("activation_checkpointing", hardware.get("activation_checkpointing", {}))
     partition_activations = bool(act_ckpt.get("partition_activations", False))
     cpu_checkpointing = bool(act_ckpt.get("cpu_checkpointing", False))
     # checkpoint_factor: 1.0 = no checkpointing (full activations), 0.1 = aggressive checkpointing
@@ -1394,11 +1697,15 @@ def normalize_deepspeed_config(config: dict) -> dict:
     elif fp16_cfg.get("enabled", False):
         hardware["_precision"] = "fp16"
 
-    # 4. Parse training settings from root level (DeepSpeed-style)
+    # 4. Parse training settings (root level or nested in hardware)
     if "train_micro_batch_size_per_gpu" in config:
         hardware["_micro_batch_size"] = config["train_micro_batch_size_per_gpu"]
+    elif "train_micro_batch_size_per_gpu" in hardware:
+        hardware["_micro_batch_size"] = hardware["train_micro_batch_size_per_gpu"]
     if "gradient_accumulation_steps" in config:
         hardware["_gradient_accumulation_steps"] = config["gradient_accumulation_steps"]
+    elif "gradient_accumulation_steps" in hardware:
+        hardware["_gradient_accumulation_steps"] = hardware["gradient_accumulation_steps"]
 
     # 5. Parse mfu from root level (our addition)
     if "mfu" in config and "mfu" not in hardware:
@@ -1713,6 +2020,11 @@ def main() -> None:
         default="config.json",
         help="Path to JSON config file",
     )
+    parser.add_argument(
+        "--upcycling-only",
+        action="store_true",
+        help="Only show upcycling cost comparison (no training tables)",
+    )
     args = parser.parse_args()
 
     config = load_config(args.config)
@@ -1761,6 +2073,132 @@ def main() -> None:
     growth_cfg = config.get("growth", {"mode": "none"})
     apply_growth_allocation(stages, growth_cfg)
 
+    # =========================================================================
+    # Upcycling-Only Mode: Show just upcycling cost comparison
+    # =========================================================================
+    if args.upcycling_only:
+        print("=" * 90)
+        print("MoE UPCYCLING COST COMPARISON (One-Time Dense→MoE Conversion)")
+        print("=" * 90)
+        print()
+        
+        # Check if any stage has upcycling configured
+        upcycling_stages = []
+        for stage in stages:
+            upcycling_info = stage.calculate_upcycling_flops()
+            if upcycling_info["method"] != "none":
+                upcycling_stages.append((stage, upcycling_info))
+        
+        if not upcycling_stages:
+            print("⚠️  No upcycling configuration found in any stage.")
+            print("   Add 'upcycling' block to architecture with 'method': 'slicing|random_projection|svd'")
+            print()
+            return
+        
+        # Header
+        print(f"{'Stage Name':<35} | {'Method':<18} | {'FLOPs':<18} | {'Time (H100)':<12} | {'Cost':<10}")
+        print("-" * 100)
+        
+        total_upcycling_flops = 0
+        total_upcycling_time = 0
+        
+        for stage, upcycling_info in upcycling_stages:
+            method = upcycling_info["method"]
+            flops = upcycling_info["upcycling_flops"]
+            time_s = upcycling_info["upcycling_time_seconds"]
+            src = upcycling_info.get("source_intermediate", "?")
+            tgt = upcycling_info.get("target_intermediate", "?")
+            n_experts = upcycling_info.get("num_experts", "?")
+            
+            total_upcycling_flops += flops
+            total_upcycling_time += time_s
+            
+            # Format FLOPs nicely
+            if flops >= 1e12:
+                flops_str = f"{flops/1e12:.2f} TFLOPs"
+            elif flops >= 1e9:
+                flops_str = f"{flops/1e9:.2f} GFLOPs"
+            elif flops >= 1e6:
+                flops_str = f"{flops/1e6:.2f} MFLOPs"
+            else:
+                flops_str = "0 (copy)" if flops == 0 else f"{flops:.0f} FLOPs"
+            
+            # Format time
+            if time_s >= 60:
+                time_str = f"{time_s/60:.1f} min"
+            elif time_s >= 1:
+                time_str = f"{time_s:.1f} s"
+            else:
+                time_str = f"{time_s*1000:.1f} ms" if time_s > 0 else "~0"
+            
+            stage_name = stage.name[:34] if len(stage.name) > 34 else stage.name
+            
+            # Calculate cost (time × price_per_gpu_hour)
+            cost = time_s * price_per_gpu_hour / 3600  # Convert seconds to hours
+            cost_str = f"${cost:.4f}" if cost > 0 else "$0"
+            
+            print(f"{stage_name:<35} | {method:<18} | {flops_str:<18} | {time_str:<12} | {cost_str:<10}")
+            print(f"  └─ FFN: {src}→{tgt} × {n_experts} experts, {stage.architecture.get('num_layers', '?')} layers")
+        
+        print("-" * 100)
+        
+        # Total
+        if total_upcycling_flops >= 1e12:
+            total_flops_str = f"{total_upcycling_flops/1e12:.2f} TFLOPs"
+        elif total_upcycling_flops >= 1e9:
+            total_flops_str = f"{total_upcycling_flops/1e9:.2f} GFLOPs"
+        else:
+            total_flops_str = f"{total_upcycling_flops/1e6:.2f} MFLOPs" if total_upcycling_flops > 0 else "0"
+        
+        if total_upcycling_time >= 60:
+            total_time_str = f"{total_upcycling_time/60:.1f} min"
+        elif total_upcycling_time >= 1:
+            total_time_str = f"{total_upcycling_time:.1f} s"
+        else:
+            total_time_str = f"{total_upcycling_time*1000:.1f} ms" if total_upcycling_time > 0 else "~0"
+        
+        total_cost = total_upcycling_time * price_per_gpu_hour / 3600
+        total_cost_str = f"${total_cost:.4f}" if total_cost > 0 else "$0"
+        
+        print(f"{'TOTAL':<35} | {'─':<18} | {total_flops_str:<18} | {total_time_str:<12} | {total_cost_str:<10}")
+        print("=" * 100)
+        print()
+        
+        # Summary comparison
+        print("COST COMPARISON SUMMARY:")
+        print("─" * 50)
+        slicing_time = sum(u["upcycling_time_seconds"] for _, u in upcycling_stages if u["method"] == "slicing")
+        rp_time = sum(u["upcycling_time_seconds"] for _, u in upcycling_stages if u["method"] == "random_projection")
+        svd_time = sum(u["upcycling_time_seconds"] for _, u in upcycling_stages if u["method"] == "svd")
+        
+        methods_found = []
+        if any(u["method"] == "slicing" for _, u in upcycling_stages):
+            methods_found.append(("Slicing", 0, "~0 (memory copy only)"))
+        if any(u["method"] == "random_projection" for _, u in upcycling_stages):
+            rp_flops = sum(u["upcycling_flops"] for _, u in upcycling_stages if u["method"] == "random_projection")
+            methods_found.append(("Random Projection", rp_flops, f"{rp_time*1000:.1f} ms" if rp_time < 1 else f"{rp_time:.1f} s"))
+        if any(u["method"] == "svd" for _, u in upcycling_stages):
+            svd_flops = sum(u["upcycling_flops"] for _, u in upcycling_stages if u["method"] == "svd")
+            methods_found.append(("SVD", svd_flops, f"{svd_time*1000:.1f} ms" if svd_time < 1 else f"{svd_time:.1f} s"))
+        
+        for method_name, flops, time_str in methods_found:
+            if flops >= 1e12:
+                flops_str = f"{flops/1e12:.2f} TFLOPs"
+            elif flops >= 1e9:
+                flops_str = f"{flops/1e9:.2f} GFLOPs"
+            else:
+                flops_str = "0 FLOPs" if flops == 0 else f"{flops/1e6:.2f} MFLOPs"
+            print(f"  • {method_name:<20}: {flops_str:<18} | {time_str}")
+        
+        print()
+        print("NOTE: All methods produce the SAME MoE architecture.")
+        print("      Choose based on quality vs compute tradeoff:")
+        print("      - Slicing: Fastest, may lose information")
+        print("      - Random Projection: Fast, preserves structure stochastically")  
+        print("      - SVD: Slowest, best information preservation")
+        print()
+        return
+
     # Effective MFU after all overheads (or compute MFU if explicit comm model)
     effective_mfu = compute_mfu if use_explicit_comm_model else mfu * zero_eff * scaling_eff
     offload_str = " + CPU Offload" if cpu_offload else ""
@@ -1796,13 +2234,13 @@ def main() -> None:
         print(f"{'-'*120}")
         if cpu_offload:
             print(
-                f"{'Stage':<20} | {'Tokens (B)':<10} | {'Total Params':<12} | {'Active Params':<12} | {'Mem/GPU (GB)':<12} | {'Mem/CPU (GB)':<12} | {'ZFLOPs':<7} | {'Days':<6} | {'Cost ($)':<12}"
+                f"{'Stage':<36} | {'Tokens (B)':<10} | {'Total Params':<12} | {'Active Params':<12} | {'Mem/GPU (GB)':<12} | {'Mem/CPU (GB)':<12} | {'ZFLOPs':<7} | {'Days':<6} | {'Cost ($)':<12}"
             )
         else:
             print(
-                f"{'Stage':<20} | {'Tokens (B)':<10} | {'Total Params':<12} | {'Active Params':<12} | {'Mem/GPU (GB)':<12} | {'ZFLOPs':<7} | {'Days':<6} | {'Cost ($)':<12}"
+                f"{'Stage':<36} | {'Tokens (B)':<10} | {'Total Params':<12} | {'Active Params':<12} | {'Mem/GPU (GB)':<12} | {'ZFLOPs':<7} | {'Days':<6} | {'Cost ($)':<12}"
             )
-        print(f"{'-'*120}")
+        print(f"{'-'*136}")
 
         total_flops = 0.0
         total_seconds = 0.0
@@ -1850,28 +2288,102 @@ def main() -> None:
             if cpu_offload:
                 cpu_mem_gb = mem_info.get("cpu_memory_per_gpu_gb", 0)
                 mem_str_cpu = f"{cpu_mem_gb:<6.1f}"
+                stage_name = stage.name[:35] if len(stage.name) > 35 else stage.name
                 print(
-                    f"{stage.name:<20} | {stage.total_tokens/1e9:<10.1f} | {params['total_params']/1e9:<5.1f} B       | {params['active_params']/1e9:<5.1f} B       | {mem_str_gpu:<12} | {mem_str_cpu:<12} | {stage_flops/1e21:<7.2f} | {stage_days:<6.2f} | ${stage_cost:,.0f}"
+                    f"{stage_name:<36} | {stage.total_tokens/1e9:<10.1f} | {params['total_params']/1e9:<5.2f} B       | {params['active_params']/1e9:<5.2f} B       | {mem_str_gpu:<12} | {mem_str_cpu:<12} | {stage_flops/1e21:<7.2f} | {stage_days:<6.2f} | ${stage_cost:,.0f}"
                 )
             else:
+                stage_name = stage.name[:35] if len(stage.name) > 35 else stage.name
                 print(
-                    f"{stage.name:<20} | {stage.total_tokens/1e9:<10.1f} | {params['total_params']/1e9:<5.1f} B       | {params['active_params']/1e9:<5.1f} B       | {mem_str_gpu:<12} | {stage_flops/1e21:<7.2f} | {stage_days:<6.2f} | ${stage_cost:,.0f}"
+                    f"{stage_name:<36} | {stage.total_tokens/1e9:<10.1f} | {params['total_params']/1e9:<5.2f} B       | {params['active_params']/1e9:<5.2f} B       | {mem_str_gpu:<12} | {stage_flops/1e21:<7.2f} | {stage_days:<6.2f} | ${stage_cost:,.0f}"
                 )
 
         total_days = total_seconds / (24 * 3600)
         total_hours = total_seconds / 3600
         total_cost = total_hours * num_gpus * price_per_gpu_hour
 
-        print(f"{'-'*120}")
+        print(f"{'-'*136}")
         if cpu_offload:
             print(
-                f"{'TOTAL':<20} | {'-':<10} | {'-':<12} | {'-':<12} | {'-':<12} | {'-':<12} | {total_flops/1e21:<7.2f} | {total_days:<6.2f} | ${total_cost:,.0f}"
+                f"{'TOTAL':<36} | {'-':<10} | {'-':<12} | {'-':<12} | {'-':<12} | {'-':<12} | {total_flops/1e21:<7.2f} | {total_days:<6.2f} | ${total_cost:,.0f}"
             )
         else:
             print(
-                f"{'TOTAL':<20} | {'-':<10} | {'-':<12} | {'-':<12} | {'-':<12} | {total_flops/1e21:<7.2f} | {total_days:<6.2f} | ${total_cost:,.0f}"
+                f"{'TOTAL':<36} | {'-':<10} | {'-':<12} | {'-':<12} | {'-':<12} | {total_flops/1e21:<7.2f} | {total_days:<6.2f} | ${total_cost:,.0f}"
             )
-        print(f"{'='*120}\n")
+        print(f"{'='*136}")
+        
+        # =====================================================================
+        # Upcycling Cost (One-Time)
+        # =====================================================================
+        # Check if any stage has upcycling configured
+        upcycling_stages = []
+        for stage in stages:
+            upcycling_info = stage.calculate_upcycling_flops()
+            if upcycling_info["method"] != "none":
+                upcycling_stages.append((stage, upcycling_info))
+        
+        if upcycling_stages:
+            print(f"\n{'─'*80}")
+            print(f"UPCYCLING COST (One-Time Dense→MoE Conversion)")
+            print(f"{'─'*80}")
+            
+            total_upcycling_flops = 0
+            total_upcycling_time = 0
+            
+            for stage, upcycling_info in upcycling_stages:
+                method = upcycling_info["method"]
+                flops = upcycling_info["upcycling_flops"]
+                time_s = upcycling_info["upcycling_time_seconds"]
+                src = upcycling_info.get("source_intermediate", "?")
+                tgt = upcycling_info.get("target_intermediate", "?")
+                n_experts = upcycling_info.get("num_experts", "?")
+                
+                total_upcycling_flops += flops
+                total_upcycling_time += time_s
+                
+                # Format FLOPs nicely
+                if flops >= 1e12:
+                    flops_str = f"{flops/1e12:.2f} TFLOPs"
+                elif flops >= 1e9:
+                    flops_str = f"{flops/1e9:.2f} GFLOPs"
+                elif flops >= 1e6:
+                    flops_str = f"{flops/1e6:.2f} MFLOPs"
+                else:
+                    flops_str = f"{flops:.0f} FLOPs" if flops > 0 else "0 (memory copy)"
+                
+                # Format time
+                if time_s >= 60:
+                    time_str = f"{time_s/60:.1f} min"
+                elif time_s >= 1:
+                    time_str = f"{time_s:.1f} s"
+                else:
+                    time_str = f"{time_s*1000:.1f} ms" if time_s > 0 else "~0"
+                
+                stage_name = stage.name[:30] if len(stage.name) > 30 else stage.name
+                print(f"  {stage_name:<32} | Method: {method:<18} | {flops_str:<18} | Est. Time: {time_str}")
+                print(f"  {'':<32} | FFN: {src}→{tgt} × {n_experts} experts")
+            
+            print(f"{'─'*80}")
+            
+            # Total
+            if total_upcycling_flops >= 1e12:
+                total_flops_str = f"{total_upcycling_flops/1e12:.2f} TFLOPs"
+            elif total_upcycling_flops >= 1e9:
+                total_flops_str = f"{total_upcycling_flops/1e9:.2f} GFLOPs"
+            else:
+                total_flops_str = f"{total_upcycling_flops/1e6:.2f} MFLOPs" if total_upcycling_flops > 0 else "0"
+            
+            if total_upcycling_time >= 60:
+                total_time_str = f"{total_upcycling_time/60:.1f} min"
+            elif total_upcycling_time >= 1:
+                total_time_str = f"{total_upcycling_time:.1f} s"
+            else:
+                total_time_str = f"{total_upcycling_time*1000:.1f} ms" if total_upcycling_time > 0 else "~0"
+            
+            print(f"  {'TOTAL UPCYCLING':<32} | {total_flops_str:<18} | Est. Time: {total_time_str} (H100 @ 50% util)")
+            print(f"{'─'*80}")
+        print()
 
 
 if __name__ == "__main__":

--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/compute.py
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/compute.py
@@ -203,7 +203,6 @@ class TrainingStage:
         arch = self.architecture
         attention_cfg = arch.get("attention") or {}
         router_cfg = arch.get("router") or {}
-        position_cfg = arch.get("position") or {}
         expert_cfg = arch.get("expert") or {}
         head_cfg = arch.get("head") or {}
 
@@ -837,7 +836,6 @@ class TrainingStage:
 
         attention_cfg = arch.get("attention") or {}
         router_cfg = arch.get("router") or {}
-        position_cfg = arch.get("position") or {}
         training_cfg = arch.get("training") or {}
         head_cfg = arch.get("head") or {}
 
@@ -940,20 +938,8 @@ class TrainingStage:
         attention_multiplier = float(attention_multiplier)
         if attention_multiplier <= 0:
             raise ValueError("attention_flops_multiplier must be > 0.")
-
-        position_type = str(
-            arch.get("position_type", position_cfg.get("position_type", ""))
-        ).strip().lower()
-        yarn_multiplier = arch.get(
-            "yarn_flops_multiplier", position_cfg.get("yarn_flops_multiplier")
-        )
-        if yarn_multiplier is None:
-            yarn_multiplier = 1.0
-        yarn_multiplier = float(yarn_multiplier)
-        if yarn_multiplier <= 0:
-            raise ValueError("yarn_flops_multiplier must be > 0.")
-        if position_type in ("yarn", "yarn_rope", "yarn_embedding"):
-            attention_multiplier *= yarn_multiplier
+        # Note: YaRN position encoding has zero FLOPs overhead compared to standard RoPE.
+        # The cost of longer contexts is captured in the O(S²) attention formula via sequence_length.
 
         num_heads = arch.get(
             "num_heads", attention_cfg.get("num_attention_heads", 32)

--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/compute.py
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/compute.py
@@ -84,6 +84,8 @@ def parse_attention_type(attention_str: str, num_heads: int = 32) -> dict:
                 "gsa": "gsa", "gated_sparse": "gsa",
                 "mha": "mha", "standard": "mha",
                 "dsa": "dsa", "mla": "dsa", "deepseek_mla": "dsa",
+                "deltanet": "deltanet", "delta": "deltanet", 
+                "linear": "deltanet", "gated_linear": "deltanet",
             }
             type1 = type_aliases.get(type1, type1)
             type2 = type_aliases.get(type2, type2)
@@ -93,13 +95,14 @@ def parse_attention_type(attention_str: str, num_heads: int = 32) -> dict:
                 "kv_ratio": 1.0,  # Will be computed per-layer
                 "sparse_k": sparse_k if "gsa" in [type1, type2] else None,
                 "mla_rank": 0,
+                "is_linear": "deltanet" in [type1, type2],  # Has linear attention component
                 "hybrid_config": {
                     "type1": type1,
                     "type2": type2,
                     "ratio1": ratio1,
                     "ratio2": ratio2,
-                    "layer_weight_type1": ratio1 / (ratio1 + ratio2),  # e.g., 0.8 for 4:1
-                    "layer_weight_type2": ratio2 / (ratio1 + ratio2),  # e.g., 0.2 for 4:1
+                    "layer_weight_type1": ratio1 / (ratio1 + ratio2),  # e.g., 0.75 for 3:1
+                    "layer_weight_type2": ratio2 / (ratio1 + ratio2),  # e.g., 0.25 for 3:1
                 },
             }
     
@@ -130,6 +133,12 @@ def parse_attention_type(attention_str: str, num_heads: int = 32) -> dict:
         "deepseek_mla": "dsa",
         "deepseek_sparse": "dsa",
         "deepseek": "dsa",
+        # DeltaNet (linear attention) aliases
+        "deltanet": "deltanet",
+        "delta": "deltanet",
+        "linear": "deltanet",
+        "gated_linear": "deltanet",
+        "gated_deltanet": "deltanet",
     }
     attn_type = type_aliases.get(attn_type, attn_type)
 
@@ -138,6 +147,7 @@ def parse_attention_type(attention_str: str, num_heads: int = 32) -> dict:
         "kv_ratio": 1.0,      # KV heads / Q heads (1.0 = MHA, 0.125 = 8:1 GQA)
         "sparse_k": None,     # Sparse attention k tokens
         "mla_rank": 0,        # MLA/DSA compression rank
+        "is_linear": attn_type == "deltanet",  # Linear attention (O(Ld²) vs O(L²d))
         "hybrid_config": None,  # For hybrid attention
     }
 
@@ -361,6 +371,70 @@ class TrainingStage:
             )
         )
 
+        # =========================================================================
+        # DeltaNet Parameters (Gated Linear Attention)
+        # DeltaNet has: Q/K/V/G/O projections + beta gate + alpha gate + A_log + D + short convs
+        # O(Ld²) complexity vs O(L²d) for standard attention
+        # =========================================================================
+        deltanet_in_hybrid = (
+            parsed_attn.get("type") == "hybrid" and 
+            parsed_attn.get("hybrid_config") and 
+            "deltanet" in [parsed_attn["hybrid_config"].get("type1"), parsed_attn["hybrid_config"].get("type2")]
+        )
+        deltanet_enabled = attention_type in (
+            "deltanet", "delta", "linear", "gated_linear", "gated_deltanet"
+        ) or bool(arch.get("use_deltanet", False)) or deltanet_in_hybrid
+        
+        # DeltaNet config
+        deltanet_cfg = arch.get("deltanet", attention_cfg.get("deltanet", {}))
+        delta_num_heads = deltanet_cfg.get("num_heads", num_heads or 32)
+        delta_head_dim = deltanet_cfg.get("head_dim", hidden // delta_num_heads if delta_num_heads else 128)
+        delta_conv_size = deltanet_cfg.get("conv_size", 4)  # Short convolution kernel size
+        
+        # Calculate layer distribution for hybrid
+        deltanet_layer_weight = 0.0
+        gsa_layer_weight = 0.0
+        if parsed_attn.get("type") == "hybrid" and parsed_attn.get("hybrid_config"):
+            hc = parsed_attn["hybrid_config"]
+            if hc.get("type1") == "deltanet":
+                deltanet_layer_weight = hc.get("layer_weight_type1", 0.75)
+                gsa_layer_weight = hc.get("layer_weight_type2", 0.25)
+            elif hc.get("type2") == "deltanet":
+                deltanet_layer_weight = hc.get("layer_weight_type2", 0.25)
+                gsa_layer_weight = hc.get("layer_weight_type1", 0.75)
+        elif deltanet_enabled and not deltanet_in_hybrid:
+            deltanet_layer_weight = 1.0
+        
+        num_deltanet_layers = int(layers * deltanet_layer_weight)
+        num_gsa_layers_hybrid = int(layers * gsa_layer_weight) if deltanet_in_hybrid else 0
+        
+        # DeltaNet-specific parameters per layer
+        deltanet_extra_params_per_layer = 0
+        if deltanet_enabled:
+            # Beta gate: H -> num_heads (weight + bias)
+            beta_gate_params = hidden * delta_num_heads + delta_num_heads
+            # Alpha (gk) gate: H -> num_heads (weight + bias)
+            alpha_gate_params = hidden * delta_num_heads + delta_num_heads
+            # A_log: per-head decay parameter
+            a_log_params = delta_num_heads
+            # D: per-head residual parameter
+            d_params = delta_num_heads
+            # Short convolutions on Q/K/V (depthwise, kernel=conv_size)
+            short_conv_params = 3 * hidden * delta_conv_size
+            # Output norm weight (per head_dim)
+            o_norm_params = delta_head_dim
+            
+            deltanet_extra_params_per_layer = (
+                beta_gate_params + alpha_gate_params + a_log_params + 
+                d_params + short_conv_params + o_norm_params
+            )
+            
+            # DeltaNet uses 5 projections: Q, K, V, G (output gate), O
+            # Standard attention: Q, K, V, O (4 projections with KV ratio)
+            # DeltaNet adds G projection: +H*H params per layer
+            deltanet_g_proj_params = hidden * hidden
+            deltanet_extra_params_per_layer += deltanet_g_proj_params
+
         moe_intermediate = arch.get(
             "moe_intermediate_size", expert_cfg.get("intermediate_size", intermediate)
         )
@@ -501,6 +575,7 @@ class TrainingStage:
             embedding_params
             + lm_head_params
             + layers * attn_params_per_layer
+            + num_deltanet_layers * deltanet_extra_params_per_layer  # DeltaNet-specific params
             + dense_layers * ffn_params_dense
             + num_moe_layers * total_ffn_params_moe
             + norm_params
@@ -508,6 +583,7 @@ class TrainingStage:
 
         active_non_embed_params = (
             layers * attn_params_per_layer
+            + num_deltanet_layers * deltanet_extra_params_per_layer  # DeltaNet-specific params
             + dense_layers * ffn_params_dense
             + num_moe_layers * active_ffn_params_moe
             + lm_head_params
@@ -515,6 +591,7 @@ class TrainingStage:
         )
         active_linear_params = (
             layers * attn_params_per_layer
+            + num_deltanet_layers * deltanet_extra_params_per_layer  # DeltaNet-specific params
             + dense_layers * ffn_params_dense
             + num_moe_layers * active_ffn_params_moe
             + lm_head_params_for_flops
@@ -954,6 +1031,86 @@ class TrainingStage:
             if attn_dim <= 0:
                 attn_dim = head_dim
 
+        # =========================================================================
+        # DeltaNet FLOPs Calculation (Gated Linear Attention)
+        # DeltaNet: O(L × d²) complexity - linear in sequence length!
+        # vs Standard Attention: O(L² × d) - quadratic in sequence length
+        # =========================================================================
+        deltanet_in_hybrid = (
+            parsed_attn.get("type") == "hybrid" and 
+            parsed_attn.get("hybrid_config") and 
+            "deltanet" in [parsed_attn["hybrid_config"].get("type1"), parsed_attn["hybrid_config"].get("type2")]
+        )
+        deltanet_enabled = attention_type in (
+            "deltanet", "delta", "linear", "gated_linear", "gated_deltanet"
+        ) or bool(arch.get("use_deltanet", False)) or deltanet_in_hybrid
+        
+        # DeltaNet config
+        deltanet_cfg = arch.get("deltanet", attention_cfg.get("deltanet", {}))
+        delta_num_heads = deltanet_cfg.get("num_heads", num_heads)
+        delta_head_dim = deltanet_cfg.get("head_dim", h // delta_num_heads if delta_num_heads else 128)
+        delta_conv_size = deltanet_cfg.get("conv_size", 4)
+        
+        # Calculate layer distribution for hybrid
+        deltanet_layer_weight = 0.0
+        gsa_layer_weight_hybrid = 0.0
+        if parsed_attn.get("type") == "hybrid" and parsed_attn.get("hybrid_config"):
+            hc = parsed_attn["hybrid_config"]
+            if hc.get("type1") == "deltanet":
+                deltanet_layer_weight = hc.get("layer_weight_type1", 0.75)
+                gsa_layer_weight_hybrid = hc.get("layer_weight_type2", 0.25)
+            elif hc.get("type2") == "deltanet":
+                deltanet_layer_weight = hc.get("layer_weight_type2", 0.25)
+                gsa_layer_weight_hybrid = hc.get("layer_weight_type1", 0.75)
+        elif deltanet_enabled and not deltanet_in_hybrid:
+            deltanet_layer_weight = 1.0
+        
+        num_deltanet_layers = int(layers * deltanet_layer_weight)
+        num_other_attn_layers = layers - num_deltanet_layers
+        
+        # DeltaNet FLOPs per layer
+        flops_per_seq_deltanet = 0
+        if deltanet_enabled and num_deltanet_layers > 0:
+            d = delta_head_dim
+            
+            # 1. Input projections: Q, K, V, G (output gate)
+            #    Each: 2 × S × H × H (matmul)
+            proj_in_flops = 4 * 2 * s * h * h
+            
+            # 2. Short convolutions on Q, K, V (depthwise, kernel=conv_size)
+            #    Each: S × H × conv_size
+            short_conv_flops = 3 * s * h * delta_conv_size
+            
+            # 3. L2 normalization on Q and K
+            #    Each: 2 × S × H (compute norm + divide)
+            l2_norm_flops = 2 * 2 * s * h
+            
+            # 4. Delta rule state updates - THE KEY O(d²) TERM
+            #    For each token: query state (d²), update state (d²), outer product (d²)
+            #    Total: 6 × d² per token per head
+            delta_rule_flops = s * delta_num_heads * d * d * 6
+            
+            # 5. Output projection: 2 × S × H × H
+            proj_out_flops = 2 * s * h * h
+            
+            # 6. Output normalization and gating (small): ~2 × S × H
+            output_ops_flops = 2 * s * h
+            
+            # Total forward FLOPs per DeltaNet layer
+            deltanet_forward_per_layer = (
+                proj_in_flops + short_conv_flops + l2_norm_flops + 
+                delta_rule_flops + proj_out_flops + output_ops_flops
+            )
+            
+            # Training multiplier (fwd + bwd)
+            base_multiplier = 3.0  # Forward (1x) + Backward (2x)
+            if use_checkpointing:
+                base_multiplier *= recompute_multiplier
+            
+            flops_per_seq_deltanet = (
+                num_deltanet_layers * deltanet_forward_per_layer * base_multiplier * attention_multiplier
+            )
+
         if use_sparse_attn:
             # Sparse attention FLOPs (DSA/GSA)
 
@@ -1009,19 +1166,22 @@ class TrainingStage:
                 indexer_flops + sparse_attn_core + mla_projection_flops
             ) * base_multiplier
 
-            # Total for all layers
-            flops_per_seq_attn = layers * sparse_attn_per_layer * attention_multiplier
+            # Total for all non-DeltaNet layers (for hybrid configs like deltanet-gsa)
+            attn_layers_for_sparse = num_other_attn_layers if deltanet_enabled else layers
+            flops_per_seq_attn_sparse = attn_layers_for_sparse * sparse_attn_per_layer * attention_multiplier
 
             # Store breakdown for debugging (optional)
             self._attn_flops_breakdown = {
-                "indexer_flops": indexer_flops * layers * base_multiplier,
-                "sparse_core_flops": sparse_attn_core * layers * base_multiplier,
+                "indexer_flops": indexer_flops * attn_layers_for_sparse * base_multiplier,
+                "sparse_core_flops": sparse_attn_core * attn_layers_for_sparse * base_multiplier,
                 "mla_projection_flops": mla_projection_flops
-                * layers
+                * attn_layers_for_sparse
                 * base_multiplier,
-                "total_attn_flops": flops_per_seq_attn,
+                "deltanet_flops": flops_per_seq_deltanet,
+                "total_attn_flops": flops_per_seq_attn_sparse + flops_per_seq_deltanet,
                 "sparse_k_tokens": sparse_k_tokens,
-                "reduction_vs_dense": (12 * layers * h * (s**2)) / flops_per_seq_attn,
+                "num_deltanet_layers": num_deltanet_layers,
+                "num_other_attn_layers": num_other_attn_layers,
             }
         else:
             # Standard Dense Attention: O(L^2)
@@ -1036,7 +1196,15 @@ class TrainingStage:
             dense_attn_per_layer = (
                 qk_matmul_flops + softmax_flops + attn_v_matmul_flops
             ) * 3.0 * recompute_multiplier
-            flops_per_seq_attn = layers * dense_attn_per_layer * attention_multiplier
+            # For hybrid configs, only apply to non-DeltaNet layers
+            attn_layers_for_dense = num_other_attn_layers if deltanet_enabled else layers
+            flops_per_seq_attn_dense = attn_layers_for_dense * dense_attn_per_layer * attention_multiplier
+        
+        # Combine DeltaNet + other attention FLOPs
+        if use_sparse_attn:
+            flops_per_seq_attn = flops_per_seq_deltanet + flops_per_seq_attn_sparse
+        else:
+            flops_per_seq_attn = flops_per_seq_deltanet + flops_per_seq_attn_dense
 
         # =========================================================================
         # MoE Router FLOPs (if MoE layers exist)

--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/moe_team8_all_stages.json
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/moe_team8_all_stages.json
@@ -1,6 +1,6 @@
 {
   "hardware": {
-    "num_gpus": 12,
+    "num_gpus": 16,
     "price_per_gpu_hour": 4,
     "tflops_per_gpu": {
       "bf16": 989.0,
@@ -91,6 +91,10 @@
         "top_k": 4,
         "moe_layer_frequency": 1,
         "tie_embeddings": true,
+        "use_multi_token_prediction": true,
+        "head": {
+          "mtp_heads": 2
+        },
         "precision": {
           "weight_precision": "auto",
           "gradient_precision": "fp32",
@@ -119,6 +123,10 @@
         "top_k": 4,
         "moe_layer_frequency": 1,
         "tie_embeddings": true,
+        "use_multi_token_prediction": true,
+        "head": {
+          "mtp_heads": 2
+        },
         "precision": {
           "weight_precision": "auto",
           "gradient_precision": "fp32",
@@ -147,6 +155,10 @@
         "top_k": 8,
         "moe_layer_frequency": 1,
         "tie_embeddings": true,
+        "use_multi_token_prediction": true,
+        "head": {
+          "mtp_heads": 2
+        },
         "precision": {
           "weight_precision": "auto",
           "gradient_precision": "fp32",

--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/stage1_1b_dense.json
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/stage1_1b_dense.json
@@ -1,49 +1,90 @@
 {
   "hardware": {
-    "num_gpus": 36,
+    "num_gpus": 8,
     "price_per_gpu_hour": 4,
     "tflops_per_gpu": {
       "bf16": 989.0,
-      "fp8": 1979.0
+      "fp8": 1979.0,
+      "nvfp4": 3500.0
     },
-    "expert_parallel_size": 1
-  },
-  "zero_optimization": {
-    "stage": 2,
-    "offload_optimizer": {
-      "device": "cpu"
+    "zero_efficiency": {
+      "zero0": 1.0,
+      "zero2": 0.95,
+      "zero3": 0.70,
+      "zero_infinity": 0.25
     },
-    "offload_param": {
-      "device": "cpu"
+    "scaling_efficiency": {
+      "base_gpus": 8,
+      "efficiency_at_base": 1.0,
+      "efficiency_at_64": 0.90,
+      "efficiency_at_256": 0.80,
+      "efficiency_at_1024": 0.65
     },
-    "pin_memory": 75
+    "expert_parallel_size": 4,
+    "cpu_offload": false,
+    "cpu_offload_config": {
+      "system_memory_limit_gb": 1000,
+      "zero_infinity": 0.25
+    },
+    "activation_checkpointing": {
+      "partition_activations": true,
+      "cpu_checkpointing": false,
+      "checkpoint_factor": 1
+    },
+    "zero_optimization": {
+      "stage": 2,
+      "offload_optimizer": {"device": "none"},
+      "offload_param": {"device": "none"}
+    },
+    "train_micro_batch_size_per_gpu": 16,
+    "gradient_accumulation_steps": 8,
+    "mfu": 0.3
   },
-  "activation_checkpointing": {
-    "partition_activations": true,
-    "cpu_checkpointing": false,
-    "checkpoint_factor": 0.1,
-    "_comment": "checkpoint_factor: 1.0=none, 0.5=half layers, 0.1=aggressive"
-  },
-  "bf16": {
-    "enabled": true
-  },
-  "train_micro_batch_size_per_gpu": 1,
-  "gradient_accumulation_steps": 1,
-  "mfu": 0.3,
   "stages": [
     {
-      "name": "Stage 1 (1B Dense)",
+      "name": "Stage 1: 1B Dense (DeltaNet+GSA)",
       "total_tokens": 20000000000,
       "architecture": {
-        "vocab_size": 32000,
-        "hidden_size": 2048,
-        "intermediate_size": 4096,
-        "num_layers": 20,
-        "sequence_length": 4096,
-        "num_heads": 16,
-        "num_kv_heads": 4,
-        "attention_type": "gqa:4:1",
-        "tie_embeddings": true,
+        "vocab_size": 131072,
+        "hidden_size": 4096,
+        "intermediate_size": 2048,
+        "moe_intermediate_size": 1024,
+        "num_layers": 8,
+        "sequence_length": 8192,
+        "num_heads": 32,
+        "num_kv_heads": 16,
+        "attention_type": "deltanet-gsa:3:1:512",
+        "deltanet": {
+          "num_deltanet_layers": 6,
+          "num_gsa_layers": 2,
+          "delta_v_heads": 32,
+          "delta_qk_heads": 16,
+          "delta_head_dim": 128,
+          "delta_gate_dim": 384,
+          "gsa_num_heads": 16,
+          "gsa_head_dim": 256,
+          "gsa_indexer_heads": 4,
+          "gsa_indexer_dim": 32,
+          "gsa_k_base": 512
+        },
+        "num_routed_experts": 0,
+        "num_null_experts": 0,
+        "num_shared_experts": 1,
+        "shared_expert_intermediate_size": 2048,
+        "top_k": 0,
+        "data_sparsity": 1.0,
+        "n_streams": 4,
+        "moe_layer_frequency": 1,
+        "use_multi_token_prediction": true,
+        "mtp_num_predictions": 2,
+        "lm_head_multiplier": 1,
+        "embedding_type": "kronecker",
+        "kronecker_config": {
+          "char_dim": 256,
+          "pos_dim": 32,
+          "D": 8192
+        },
+        "tie_embeddings": false,
         "precision": {
           "weight_precision": "auto",
           "gradient_precision": "fp32",

--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/stage2_3b_moe.json
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/stage2_3b_moe.json
@@ -1,55 +1,90 @@
 {
   "hardware": {
-    "num_gpus": 36,
+    "num_gpus": 8,
     "price_per_gpu_hour": 4,
     "tflops_per_gpu": {
       "bf16": 989.0,
-      "fp8": 1979.0
+      "fp8": 1979.0,
+      "nvfp4": 3500.0
     },
-    "expert_parallel_size": 1
-  },
-  "zero_optimization": {
-    "stage": 2,
-    "offload_optimizer": {
-      "device": "cpu"
+    "zero_efficiency": {
+      "zero0": 1.0,
+      "zero2": 0.95,
+      "zero3": 0.70,
+      "zero_infinity": 0.25
     },
-    "offload_param": {
-      "device": "cpu"
+    "scaling_efficiency": {
+      "base_gpus": 8,
+      "efficiency_at_base": 1.0,
+      "efficiency_at_64": 0.90,
+      "efficiency_at_256": 0.80,
+      "efficiency_at_1024": 0.65
     },
-    "pin_memory": 75
+    "expert_parallel_size": 4,
+    "cpu_offload": false,
+    "cpu_offload_config": {
+      "system_memory_limit_gb": 1000,
+      "zero_infinity": 0.25
+    },
+    "activation_checkpointing": {
+      "partition_activations": true,
+      "cpu_checkpointing": false,
+      "checkpoint_factor": 1
+    },
+    "zero_optimization": {
+      "stage": 2,
+      "offload_optimizer": {"device": "none"},
+      "offload_param": {"device": "none"}
+    },
+    "train_micro_batch_size_per_gpu": 16,
+    "gradient_accumulation_steps": 8,
+    "mfu": 0.3
   },
-  "activation_checkpointing": {
-    "partition_activations": true,
-    "cpu_checkpointing": false,
-    "checkpoint_factor": 0.1,
-    "_comment": "checkpoint_factor: 1.0=none, 0.5=half layers, 0.1=aggressive"
-  },
-  "bf16": {
-    "enabled": true
-  },
-  "train_micro_batch_size_per_gpu": 1,
-  "gradient_accumulation_steps": 1,
-  "mfu": 0.3,
   "stages": [
     {
-      "name": "Stage 2 (3B MoE)",
-      "total_tokens": 40000000000,
+      "name": "Stage 2: 3B MoE (DeltaNet+GSA)",
+      "total_tokens": 50000000000,
       "architecture": {
-        "vocab_size": 32000,
-        "hidden_size": 2048,
-        "intermediate_size": 4096,
-        "moe_intermediate_size": 512,
-        "num_layers": 20,
-        "sequence_length": 4096,
-        "num_heads": 16,
-        "num_kv_heads": 4,
-        "attention_type": "gqa:4:1",
-        "num_routed_experts": 40,
-        "num_shared_experts": 2,
+        "vocab_size": 131072,
+        "hidden_size": 4096,
+        "intermediate_size": 1024,
+        "moe_intermediate_size": 1024,
+        "num_layers": 8,
+        "sequence_length": 8192,
+        "num_heads": 32,
+        "num_kv_heads": 16,
+        "attention_type": "deltanet-gsa:3:1:512",
+        "deltanet": {
+          "num_deltanet_layers": 6,
+          "num_gsa_layers": 2,
+          "delta_v_heads": 32,
+          "delta_qk_heads": 16,
+          "delta_head_dim": 128,
+          "delta_gate_dim": 384,
+          "gsa_num_heads": 16,
+          "gsa_head_dim": 256,
+          "gsa_indexer_heads": 4,
+          "gsa_indexer_dim": 32,
+          "gsa_k_base": 512
+        },
+        "num_routed_experts": 20,
         "num_null_experts": 20,
-        "top_k": 4,
+        "num_shared_experts": 1,
+        "shared_expert_intermediate_size": 2048,
+        "top_k": 2,
+        "data_sparsity": 0.5,
+        "n_streams": 4,
         "moe_layer_frequency": 1,
-        "tie_embeddings": true,
+        "use_multi_token_prediction": true,
+        "mtp_num_predictions": 2,
+        "lm_head_multiplier": 1,
+        "embedding_type": "kronecker",
+        "kronecker_config": {
+          "char_dim": 256,
+          "pos_dim": 32,
+          "D": 8192
+        },
+        "tie_embeddings": false,
         "precision": {
           "weight_precision": "auto",
           "gradient_precision": "fp32",

--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/stage3_8b_moe.json
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/stage3_8b_moe.json
@@ -1,55 +1,90 @@
 {
   "hardware": {
-    "num_gpus": 36,
+    "num_gpus": 8,
     "price_per_gpu_hour": 4,
     "tflops_per_gpu": {
       "bf16": 989.0,
-      "fp8": 1979.0
+      "fp8": 1979.0,
+      "nvfp4": 3500.0
     },
-    "expert_parallel_size": 1
-  },
-  "zero_optimization": {
-    "stage": 2,
-    "offload_optimizer": {
-      "device": "cpu"
+    "zero_efficiency": {
+      "zero0": 1.0,
+      "zero2": 0.95,
+      "zero3": 0.70,
+      "zero_infinity": 0.25
     },
-    "offload_param": {
-      "device": "cpu"
+    "scaling_efficiency": {
+      "base_gpus": 8,
+      "efficiency_at_base": 1.0,
+      "efficiency_at_64": 0.90,
+      "efficiency_at_256": 0.80,
+      "efficiency_at_1024": 0.65
     },
-    "pin_memory": 75
+    "expert_parallel_size": 4,
+    "cpu_offload": false,
+    "cpu_offload_config": {
+      "system_memory_limit_gb": 1000,
+      "zero_infinity": 0.25
+    },
+    "activation_checkpointing": {
+      "partition_activations": true,
+      "cpu_checkpointing": false,
+      "checkpoint_factor": 1
+    },
+    "zero_optimization": {
+      "stage": 2,
+      "offload_optimizer": {"device": "none"},
+      "offload_param": {"device": "none"}
+    },
+    "train_micro_batch_size_per_gpu": 16,
+    "gradient_accumulation_steps": 8,
+    "mfu": 0.3
   },
-  "activation_checkpointing": {
-    "partition_activations": true,
-    "cpu_checkpointing": false,
-    "checkpoint_factor": 0.1,
-    "_comment": "checkpoint_factor: 1.0=none, 0.5=half layers, 0.1=aggressive"
-  },
-  "bf16": {
-    "enabled": true
-  },
-  "train_micro_batch_size_per_gpu": 1,
-  "gradient_accumulation_steps": 1,
-  "mfu": 0.3,
   "stages": [
     {
-      "name": "Stage 3 (8B MoE)",
+      "name": "Stage 3: 8B MoE (DeltaNet+GSA)",
       "total_tokens": 100000000000,
       "architecture": {
-        "vocab_size": 32000,
-        "hidden_size": 2048,
-        "intermediate_size": 4096,
-        "moe_intermediate_size": 512,
-        "num_layers": 40,
-        "sequence_length": 4096,
-        "num_heads": 16,
-        "num_kv_heads": 4,
-        "attention_type": "gqa:4:1",
-        "num_routed_experts": 40,
-        "num_shared_experts": 2,
+        "vocab_size": 131072,
+        "hidden_size": 4096,
+        "intermediate_size": 1024,
+        "moe_intermediate_size": 1024,
+        "num_layers": 20,
+        "sequence_length": 8192,
+        "num_heads": 32,
+        "num_kv_heads": 16,
+        "attention_type": "deltanet-gsa:3:1:512",
+        "deltanet": {
+          "num_deltanet_layers": 15,
+          "num_gsa_layers": 5,
+          "delta_v_heads": 32,
+          "delta_qk_heads": 16,
+          "delta_head_dim": 128,
+          "delta_gate_dim": 384,
+          "gsa_num_heads": 16,
+          "gsa_head_dim": 256,
+          "gsa_indexer_heads": 4,
+          "gsa_indexer_dim": 32,
+          "gsa_k_base": 512
+        },
+        "num_routed_experts": 20,
         "num_null_experts": 20,
-        "top_k": 4,
+        "num_shared_experts": 1,
+        "shared_expert_intermediate_size": 2048,
+        "top_k": 2,
+        "data_sparsity": 0.5,
+        "n_streams": 4,
         "moe_layer_frequency": 1,
-        "tie_embeddings": true,
+        "use_multi_token_prediction": true,
+        "mtp_num_predictions": 2,
+        "lm_head_multiplier": 1,
+        "embedding_type": "kronecker",
+        "kronecker_config": {
+          "char_dim": 256,
+          "pos_dim": 32,
+          "D": 8192
+        },
+        "tie_embeddings": false,
         "precision": {
           "weight_precision": "auto",
           "gradient_precision": "fp32",

--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/stage4_70b_moe.json
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/stage4_70b_moe.json
@@ -1,55 +1,91 @@
 {
   "hardware": {
-    "num_gpus": 36,
-    "price_per_gpu_hour": 4,
+    "description": "AWS p5en.48xlarge: 8x NVIDIA H200 SXM (141GB HBM3e each)",
+    "num_gpus": 8,
+    "price_per_gpu_hour": 5.20,
     "tflops_per_gpu": {
-      "bf16": 989.0,
-      "fp8": 1979.0
+      "bf16": 1979.0,
+      "fp8": 3958.0
     },
-    "expert_parallel_size": 1
-  },
-  "zero_optimization": {
-    "stage": 2,
-    "offload_optimizer": {
-      "device": "cpu"
+    "gpu_memory_gb": 141,
+    "zero_efficiency": {
+      "zero0": 1.0,
+      "zero2": 0.95,
+      "zero3": 0.70,
+      "zero_infinity": 0.25
     },
-    "offload_param": {
-      "device": "cpu"
+    "scaling_efficiency": {
+      "base_gpus": 8,
+      "efficiency_at_base": 1.0,
+      "efficiency_at_64": 0.90,
+      "efficiency_at_256": 0.80,
+      "efficiency_at_1024": 0.65
     },
-    "pin_memory": 75
+    "expert_parallel_size": 8,
+    "cpu_offload": false,
+    "cpu_offload_config": {
+      "system_memory_limit_gb": 1000,
+      "zero_infinity": 0.25
+    },
+    "activation_checkpointing": {
+      "partition_activations": true,
+      "cpu_checkpointing": false,
+      "checkpoint_factor": 1
+    },
+    "zero_optimization": {
+      "stage": 2,
+      "offload_optimizer": {"device": "none"},
+      "offload_param": {"device": "none"}
+    },
+    "train_micro_batch_size_per_gpu": 8,
+    "gradient_accumulation_steps": 16,
+    "mfu": 0.3
   },
-  "activation_checkpointing": {
-    "partition_activations": true,
-    "cpu_checkpointing": false,
-    "checkpoint_factor": 0.1,
-    "_comment": "checkpoint_factor: 1.0=none, 0.5=half layers, 0.1=aggressive"
-  },
-  "bf16": {
-    "enabled": true
-  },
-  "train_micro_batch_size_per_gpu": 1,
-  "gradient_accumulation_steps": 1,
-  "mfu": 0.3,
   "stages": [
     {
-      "name": "Stage 4 (70B MoE)",
-      "total_tokens": 240000000000,
+      "name": "Stage 4: 70B MoE (DeltaNet+GSA)",
+      "total_tokens": 200000000000,
       "architecture": {
-        "vocab_size": 32000,
-        "hidden_size": 2048,
-        "intermediate_size": 4096,
-        "moe_intermediate_size": 512,
-        "num_layers": 40,
-        "sequence_length": 4096,
-        "num_heads": 16,
-        "num_kv_heads": 4,
-        "attention_type": "gqa:4:1",
-        "num_routed_experts": 512,
-        "num_shared_experts": 4,
+        "vocab_size": 131072,
+        "hidden_size": 4096,
+        "intermediate_size": 1024,
+        "moe_intermediate_size": 1024,
+        "num_layers": 20,
+        "sequence_length": 8192,
+        "num_heads": 32,
+        "num_kv_heads": 16,
+        "attention_type": "deltanet-gsa:3:1:512",
+        "deltanet": {
+          "num_deltanet_layers": 15,
+          "num_gsa_layers": 5,
+          "delta_v_heads": 32,
+          "delta_qk_heads": 16,
+          "delta_head_dim": 128,
+          "delta_gate_dim": 384,
+          "gsa_num_heads": 16,
+          "gsa_head_dim": 256,
+          "gsa_indexer_heads": 4,
+          "gsa_indexer_dim": 32,
+          "gsa_k_base": 512
+        },
+        "num_routed_experts": 256,
         "num_null_experts": 256,
+        "num_shared_experts": 1,
+        "shared_expert_intermediate_size": 2048,
         "top_k": 8,
+        "data_sparsity": 0.5,
+        "n_streams": 4,
         "moe_layer_frequency": 1,
-        "tie_embeddings": true,
+        "use_multi_token_prediction": true,
+        "mtp_num_predictions": 2,
+        "lm_head_multiplier": 1,
+        "embedding_type": "kronecker",
+        "kronecker_config": {
+          "char_dim": 256,
+          "pos_dim": 32,
+          "D": 8192
+        },
+        "tie_embeddings": false,
         "precision": {
           "weight_precision": "auto",
           "gradient_precision": "fp32",

--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/test_deltanet_gsa.json
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/test_deltanet_gsa.json
@@ -1,0 +1,65 @@
+{
+  "hardware": {
+    "num_gpus": 16,
+    "price_per_gpu_hour": 4,
+    "tflops_per_gpu": {
+      "bf16": 989.0,
+      "fp8": 1979.0
+    },
+    "expert_parallel_size": 8,
+    "zero_efficiency": {
+      "zero0": 1.0,
+      "zero2": 0.95,
+      "zero3": 0.70
+    },
+    "scaling_efficiency": {
+      "base_gpus": 8,
+      "efficiency_at_base": 1.0,
+      "efficiency_at_64": 0.90
+    }
+  },
+  "zero_optimization": {
+    "stage": 2
+  },
+  "activation_checkpointing": {
+    "partition_activations": true
+  },
+  "train_micro_batch_size_per_gpu": 4,
+  "gradient_accumulation_steps": 16,
+  "mfu": 0.3,
+  "stages": [
+    {
+      "name": "70B MoE with DeltaNet-GSA Hybrid",
+      "total_tokens": 240000000000,
+      "architecture": {
+        "vocab_size": 131072,
+        "hidden_size": 4096,
+        "intermediate_size": 4096,
+        "moe_intermediate_size": 1024,
+        "num_layers": 20,
+        "sequence_length": 262144,
+        "num_heads": 32,
+        "num_kv_heads": 8,
+        "attention_type": "deltanet-gsa:3:1:512",
+        "num_routed_experts": 270,
+        "num_shared_experts": 1,
+        "num_null_experts": 270,
+        "top_k": 10,
+        "moe_layer_frequency": 1,
+        "tie_embeddings": false,
+        "deltanet": {
+          "num_heads": 32,
+          "head_dim": 128,
+          "conv_size": 4
+        },
+        "precision": {
+          "weight_precision": "bf16",
+          "gradient_precision": "fp32",
+          "optimizer_precision": "fp32",
+          "optimizer_states_count": 2,
+          "master_weights": false
+        }
+      }
+    }
+  ]
+}

--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/test_deltanet_gsa.json
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/test_deltanet_gsa.json
@@ -37,7 +37,7 @@
         "intermediate_size": 4096,
         "moe_intermediate_size": 1024,
         "num_layers": 20,
-        "sequence_length": 262144,
+        "sequence_length": 4096,
         "num_heads": 32,
         "num_kv_heads": 8,
         "attention_type": "deltanet-gsa:3:1:512",

--- a/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/upcycling_comparison.json
+++ b/experiments/9_training_stack_optimisation_and_cost_governor/FLOPS-Calculation/configs/moe_team8/upcycling_comparison.json
@@ -1,0 +1,46 @@
+{
+  "hardware": {
+    "num_gpus": 1,
+    "price_per_gpu_hour": 4,
+    "tflops_per_gpu": {"bf16": 989.0},
+    "mfu": 0.3
+  },
+  "stages": [
+    {
+      "name": "1B→3B Slicing",
+      "total_tokens": 1,
+      "architecture": {
+        "hidden_size": 2048,
+        "intermediate_size": 4096,
+        "moe_intermediate_size": 1024,
+        "num_layers": 16,
+        "num_routed_experts": 20,
+        "upcycling": {"method": "slicing"}
+      }
+    },
+    {
+      "name": "1B→3B Random Projection",
+      "total_tokens": 1,
+      "architecture": {
+        "hidden_size": 2048,
+        "intermediate_size": 4096,
+        "moe_intermediate_size": 1024,
+        "num_layers": 16,
+        "num_routed_experts": 20,
+        "upcycling": {"method": "random_projection"}
+      }
+    },
+    {
+      "name": "1B→3B SVD",
+      "total_tokens": 1,
+      "architecture": {
+        "hidden_size": 2048,
+        "intermediate_size": 4096,
+        "moe_intermediate_size": 1024,
+        "num_layers": 16,
+        "num_routed_experts": 20,
+        "upcycling": {"method": "svd"}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Changes

### Parameter Calculation Fixes
- Fix GSA value gate: use `H*H` instead of `H*H*kv_ratio`
- Fix GSA indexer formula: `W_Iq + W_Ik + W_Iw + bias`
- Add missing DeltaNet `dt_bias` parameter
- Fix MTP block: use pure DeltaNet params (not GSA-contaminated)
- Fix `active_params`: report `active_base` (not null-blended)

### Config Parsing Fix
- `normalize_deepspeed_config` now reads `activation_checkpointing`, `zero_optimization`, `train_micro_batch_size_per_gpu`, and `gradient_accumulation_steps` from inside `hardware` block when not found at root level

### DeltaNet Support
- Full DeltaNet linear attention parameter and FLOP calculations
- Hybrid DeltaNet-GSA attention type (`deltanet-gsa:3:1:512`)
- O(S×d²) complexity modeling vs O(S²×d) for standard attention

### README Updates
- Kronecker Product Embeddings (KPE) documentation
- Multi-Head Composition (mHC) documentation
- DeltaNet attention documentation

### Config Updates
- Update 70B price to $5.20/GPU/hr (p5en.48xlarge Mumbai on-demand)
- Update 70B micro_batch=8, gradient_accumulation=16
- All MoE configs updated with DeltaNet+GSA hybrid attention