### PR TITLE
feat: integrate OPUS data selection into training pipeline

### DIFF
--- a/llm/configs/config.yaml
+++ b/llm/configs/config.yaml
@@ -64,3 +64,25 @@ s3:
 generation:
   test_generation: false
   generation_prompt: "The history of artificial intelligence begins with"
+
+# OPUS Data Selection (arXiv:2602.05400)
+# When enabled, each training step scores N candidate samples and trains on
+# the best rho*N samples, guided by AdamW preconditioner geometry.
+opus:
+  enabled: false
+  selection_mode: "opus"
+  candidate_multiplier: 2
+  selection_ratio: 0.5
+  score_seq_len: 512
+  proxy_batch_size: 8
+  sketch_dim: 8192
+  temperature: 0.9
+  sketch_seed: 42
+  fallback_random_on_error: true
+  max_selector_time_s: 30.0
+  include_embeddings: false
+  include_lm_head: false
+  track_nonfinite_stats: true
+  zero2_exact_global_scoring: true
+  strict_shard_preconditioner: false
+  log_selection_metrics: true

--- a/llm/configs/config.yaml
+++ b/llm/configs/config.yaml
@@ -83,6 +83,6 @@ opus:
   include_embeddings: false
   include_lm_head: false
   track_nonfinite_stats: true
-  zero2_exact_global_scoring: true
+  zero2_exact_global_scoring: false
   strict_shard_preconditioner: false
   log_selection_metrics: true

--- a/llm/main.py
+++ b/llm/main.py
@@ -399,9 +399,19 @@ def main():
                 )
 
             print_rank_0(f"  [bin_idx] Loading train shards from: {args.shard_dir}")
+
+            # OPUS: candidate batch is multiplied
+            loader_batch_size = micro_batch_size
+            if args.opus_config.enabled:
+                loader_batch_size = micro_batch_size * args.opus_config.candidate_multiplier
+                print_rank_0(
+                    f"  [OPUS] Candidate batch size: {loader_batch_size} "
+                    f"(select {int(loader_batch_size * args.opus_config.selection_ratio)})"
+                )
+
             train_loader = build_bin_idx_dataloader(
                 shard_dir=args.shard_dir,
-                batch_size=micro_batch_size,
+                batch_size=loader_batch_size,
                 tokenizer=tokenizer,
                 tokenizer_dir=args.tokenizer_dir,
                 seq_len=args.max_length,
@@ -409,6 +419,20 @@ def main():
                 validate_tokenizer=args.validate_tokenizer,
             )
             print_rank_0(f"  [bin_idx] Train loader ready (seq_len={args.max_length})")
+
+            # OPUS: separate proxy loader from same shards
+            proxy_loader = None
+            if args.opus_config.enabled:
+                proxy_loader = build_bin_idx_dataloader(
+                    shard_dir=args.shard_dir,
+                    batch_size=args.opus_config.proxy_batch_size,
+                    tokenizer=tokenizer,
+                    tokenizer_dir=args.tokenizer_dir,
+                    seq_len=args.max_length,
+                    num_workers=min(2, args.num_workers),
+                    validate_tokenizer=False,
+                )
+                print_rank_0(f"  [OPUS] Proxy loader ready (batch={args.opus_config.proxy_batch_size})")
 
             if args.eval_shard_dir:
                 print_rank_0(
@@ -432,6 +456,8 @@ def main():
                     "  [bin_idx] No eval_shard_dir set — validation/test will be skipped."
                 )
     else:
+        if args.opus_config.enabled:
+            raise ValueError("OPUS data selection requires loader_type='bin_idx'.")
         with pipe.stage("data_load"):
             train_loader, eval_loader, test_loader, dataset_info = get_dataloaders(
                 dataset_name=args.dataset_name,
@@ -568,6 +594,28 @@ def main():
     print_rank_0(f"ZeRO Stage: {model_engine.zero_optimization_stage()}")
 
     # ========================================
+    # Step 3.1: Initialize OPUS Data Selector (if enabled)
+    # ========================================
+    opus_selector = None
+    if args.opus_config.enabled:
+        print_rank_0("\n[3.1/5] Initializing OPUS Data Selector...")
+        from llm.opus import OpusDataSelector
+
+        ds_optimizer = model_engine.optimizer
+        base_optimizer = getattr(ds_optimizer, "optimizer", ds_optimizer)
+
+        opus_selector = OpusDataSelector(
+            config=args.opus_config,
+            model=model_engine.module,
+            optimizer=base_optimizer,
+            proxy_loader=iter(proxy_loader),
+        )
+        print_rank_0(f"  OPUS mode: {args.opus_config.selection_mode}")
+        print_rank_0(f"  Selection ratio: {args.opus_config.selection_ratio}")
+        print_rank_0(f"  Sketch dim: {args.opus_config.sketch_dim}")
+        print_rank_0("  ✓ OPUS Data Selector initialized")
+
+    # ========================================
     # Step 3.5: Initialize Checkpoint Manager
     # ========================================
     checkpoint_manager = None
@@ -666,6 +714,7 @@ def main():
                     if args.metrics_jsonl_path
                     else None
                 ),
+                opus_selector=opus_selector,
             )
 
         eval_loss = None

--- a/llm/main.py
+++ b/llm/main.py
@@ -182,6 +182,12 @@ class Config:
         self.test_generation = config_dict["generation"]["test_generation"]
         self.generation_prompt = config_dict["generation"]["generation_prompt"]
 
+        # OPUS configuration
+        from llm.opus.config import OpusConfig
+
+        opus_dict = config_dict.get("opus", {})
+        self.opus_config = OpusConfig.from_dict(opus_dict) if opus_dict else OpusConfig()
+
 
 def load_config(config_path: str = "config.yaml") -> Config:
     """

--- a/llm/main.py
+++ b/llm/main.py
@@ -599,16 +599,19 @@ def main():
     opus_selector = None
     if args.opus_config.enabled:
         print_rank_0("\n[3.1/5] Initializing OPUS Data Selector...")
-        from llm.opus import OpusDataSelector
+        from llm.opus import OpusDataSelector, RandomInDistributionProxyProvider
 
         ds_optimizer = model_engine.optimizer
         base_optimizer = getattr(ds_optimizer, "optimizer", ds_optimizer)
+
+        # Wrap proxy loader with auto-resetting provider (handles epoch boundaries)
+        proxy_provider = RandomInDistributionProxyProvider(proxy_loader)
 
         opus_selector = OpusDataSelector(
             config=args.opus_config,
             model=model_engine.module,
             optimizer=base_optimizer,
-            proxy_loader=iter(proxy_loader),
+            proxy_loader=proxy_provider,
         )
         print_rank_0(f"  OPUS mode: {args.opus_config.selection_mode}")
         print_rank_0(f"  Selection ratio: {args.opus_config.selection_ratio}")

--- a/llm/src/llm/opus/__init__.py
+++ b/llm/src/llm/opus/__init__.py
@@ -1,1 +1,23 @@
 """OPUS data selection — Optimizer-induced Projected Utility Selection (arXiv:2602.05400)."""
+from .config import OpusConfig
+from .countsketch import CountSketchProjector
+from .data_selector import OpusDataSelector
+from .ghost import GhostCollector, LayerCapture, MoERoutedCapture
+from .preconditioner import AdamWPreconditionerView
+from .proxy import BenchProxyProvider, ProxyProvider, RandomInDistributionProxyProvider
+from .selector import OpusSelector, SelectionResult
+
+__all__ = [
+    "OpusConfig",
+    "OpusDataSelector",
+    "CountSketchProjector",
+    "GhostCollector",
+    "LayerCapture",
+    "MoERoutedCapture",
+    "AdamWPreconditionerView",
+    "ProxyProvider",
+    "RandomInDistributionProxyProvider",
+    "BenchProxyProvider",
+    "OpusSelector",
+    "SelectionResult",
+]

--- a/llm/src/llm/opus/__init__.py
+++ b/llm/src/llm/opus/__init__.py
@@ -1,0 +1,1 @@
+"""OPUS data selection — Optimizer-induced Projected Utility Selection (arXiv:2602.05400)."""

--- a/llm/src/llm/opus/config.py
+++ b/llm/src/llm/opus/config.py
@@ -20,7 +20,7 @@ class OpusConfig:
     include_embeddings: bool = False
     include_lm_head: bool = False
     track_nonfinite_stats: bool = True
-    zero2_exact_global_scoring: bool = True
+    zero2_exact_global_scoring: bool = False
     strict_shard_preconditioner: bool = False
     log_selection_metrics: bool = True
 

--- a/llm/src/llm/opus/config.py
+++ b/llm/src/llm/opus/config.py
@@ -1,0 +1,31 @@
+"""OpusConfig dataclass for OPUS data selection."""
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict
+
+
+@dataclass
+class OpusConfig:
+    enabled: bool = False
+    selection_mode: str = "opus"  # "opus" or "random"
+    candidate_multiplier: int = 2
+    selection_ratio: float = 0.5
+    score_seq_len: int = 512
+    proxy_batch_size: int = 8
+    sketch_dim: int = 8192
+    temperature: float = 0.9
+    sketch_seed: int = 42
+    fallback_random_on_error: bool = True
+    max_selector_time_s: float = 30.0
+    include_embeddings: bool = False
+    include_lm_head: bool = False
+    track_nonfinite_stats: bool = True
+    zero2_exact_global_scoring: bool = True
+    strict_shard_preconditioner: bool = False
+    log_selection_metrics: bool = True
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "OpusConfig":
+        valid_keys = {f.name for f in fields(cls)}
+        filtered = {k: v for k, v in d.items() if k in valid_keys}
+        return cls(**filtered)

--- a/llm/src/llm/opus/countsketch.py
+++ b/llm/src/llm/opus/countsketch.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+import torch
+
+
+@dataclass
+class _ShapeCache:
+    row_hash: torch.Tensor
+    row_sign: torch.Tensor
+    col_hash: torch.Tensor
+    col_sign: torch.Tensor
+
+
+class CountSketchProjector:
+    """
+    Deterministic CountSketch projection for linear-layer gradients.
+
+    The projector avoids materializing the full [out_dim, in_dim] gradient tensor by
+    processing row chunks and accumulating into sketch bins with scatter-add.
+    """
+
+    def __init__(self, sketch_dim: int = 8192, seed: int = 42, row_chunk_size: int = 64):
+        if sketch_dim <= 0:
+            raise ValueError("sketch_dim must be > 0")
+        self.sketch_dim = int(sketch_dim)
+        self.seed = int(seed)
+        self.row_chunk_size = int(row_chunk_size)
+        self._cache: Dict[Tuple[int, int, torch.device, int], _ShapeCache] = {}
+
+    @staticmethod
+    def _stable_key_hash(sketch_key: str) -> int:
+        if not sketch_key:
+            return 0
+        h = hashlib.blake2b(sketch_key.encode("utf-8"), digest_size=8).digest()
+        return int.from_bytes(h, byteorder="little", signed=False)
+
+    def _shape_seed(self, out_dim: int, in_dim: int, key_hash: int) -> int:
+        mixed = (
+            int(self.seed)
+            + (int(out_dim) * 1_000_003)
+            + (int(in_dim) * 1_000_033)
+            + (int(key_hash) * 1_000_037)
+        )
+        return int(mixed % (2**63 - 1))
+
+    def _get_cache(self, out_dim: int, in_dim: int, device: torch.device, sketch_key: str = "") -> _ShapeCache:
+        key_hash = self._stable_key_hash(sketch_key)
+        key = (out_dim, in_dim, device, key_hash)
+        if key in self._cache:
+            return self._cache[key]
+
+        g = torch.Generator(device="cpu")
+        g.manual_seed(self._shape_seed(out_dim, in_dim, key_hash))
+
+        row_hash = torch.randint(0, self.sketch_dim, (out_dim,), generator=g, dtype=torch.int64)
+        row_sign = torch.randint(0, 2, (out_dim,), generator=g, dtype=torch.int8).to(torch.float32)
+        row_sign = row_sign.mul_(2.0).sub_(1.0)
+
+        col_hash = torch.randint(0, self.sketch_dim, (in_dim,), generator=g, dtype=torch.int64)
+        col_sign = torch.randint(0, 2, (in_dim,), generator=g, dtype=torch.int8).to(torch.float32)
+        col_sign = col_sign.mul_(2.0).sub_(1.0)
+
+        cache = _ShapeCache(
+            row_hash=row_hash.to(device=device, non_blocking=True),
+            row_sign=row_sign.to(device=device, non_blocking=True),
+            col_hash=col_hash.to(device=device, non_blocking=True),
+            col_sign=col_sign.to(device=device, non_blocking=True),
+        )
+        self._cache[key] = cache
+        return cache
+
+    @staticmethod
+    def _ensure_btd(x: torch.Tensor) -> torch.Tensor:
+        if x.dim() == 3:
+            return x
+        if x.dim() == 2:
+            return x.unsqueeze(1)
+        raise ValueError(f"Expected tensor with dim 2 or 3, got shape {tuple(x.shape)}")
+
+    @staticmethod
+    def _sanitize_f32(x: torch.Tensor) -> torch.Tensor:
+        x = x.to(torch.float32)
+        return torch.nan_to_num(x, nan=0.0, posinf=0.0, neginf=0.0)
+
+    def project_linear_sample(
+        self,
+        activations: torch.Tensor,
+        grad_outputs: torch.Tensor,
+        preconditioner: torch.Tensor | None,
+        out_dim: int,
+        in_dim: int,
+        out_dtype: torch.dtype = torch.float32,
+        sketch_key: str = "",
+    ) -> torch.Tensor:
+        """
+        Project one sample's linear weight gradient into CountSketch space.
+
+        Args:
+            activations: [T, in_dim]
+            grad_outputs: [T, out_dim]
+            preconditioner: [out_dim, in_dim] or None
+        """
+        if activations.dim() != 2 or grad_outputs.dim() != 2:
+            raise ValueError("project_linear_sample expects [T, D] tensors")
+        if activations.shape[0] != grad_outputs.shape[0]:
+            raise ValueError("activation/grad_output token dimensions must match")
+
+        device = activations.device
+        cache = self._get_cache(out_dim, in_dim, device, sketch_key=sketch_key)
+
+        a = self._sanitize_f32(activations)
+        g = self._sanitize_f32(grad_outputs)
+        sketch = torch.zeros(self.sketch_dim, device=device, dtype=torch.float32)
+        p = self._sanitize_f32(preconditioner) if preconditioner is not None else None
+
+        # Row-chunk accumulation to bound peak memory.
+        chunk = max(1, self.row_chunk_size)
+        for row_start in range(0, out_dim, chunk):
+            row_end = min(out_dim, row_start + chunk)
+            g_chunk = g[:, row_start:row_end]  # [T, chunk]
+
+            # Equivalent to sum_t outer(g_t, a_t) for this row slice.
+            grad_chunk = g_chunk.transpose(0, 1).matmul(a)  # [chunk, in_dim]
+            grad_chunk = torch.nan_to_num(grad_chunk, nan=0.0, posinf=0.0, neginf=0.0)
+
+            if p is not None:
+                grad_chunk = grad_chunk * p[row_start:row_end]
+                grad_chunk = torch.nan_to_num(grad_chunk, nan=0.0, posinf=0.0, neginf=0.0)
+
+            pair_hash = (cache.row_hash[row_start:row_end].unsqueeze(1) + cache.col_hash.unsqueeze(0)) % self.sketch_dim
+            pair_sign = cache.row_sign[row_start:row_end].unsqueeze(1) * cache.col_sign.unsqueeze(0)
+
+            contrib = (grad_chunk * pair_sign).reshape(-1)
+            contrib = torch.nan_to_num(contrib, nan=0.0, posinf=0.0, neginf=0.0)
+            sketch.scatter_add_(0, pair_hash.reshape(-1), contrib)
+
+        sketch = torch.nan_to_num(sketch, nan=0.0, posinf=0.0, neginf=0.0)
+        return sketch.to(out_dtype)
+
+    def project_outer_sum_sample(
+        self,
+        left: torch.Tensor,
+        right: torch.Tensor,
+        preconditioner: torch.Tensor | None,
+        row_dim: int,
+        col_dim: int,
+        out_dtype: torch.dtype = torch.float32,
+        sketch_key: str = "",
+    ) -> torch.Tensor:
+        """
+        Project gradient of matrix parameter with shape [row_dim, col_dim].
+
+        Given per-token/assignment factors `left` [N, row_dim] and `right` [N, col_dim],
+        this sketches grad = left^T @ right without materializing the full matrix.
+        """
+        if left.dim() != 2 or right.dim() != 2:
+            raise ValueError("project_outer_sum_sample expects [N, D] tensors")
+        if left.shape[0] != right.shape[0]:
+            raise ValueError("left/right leading dimensions must match")
+
+        device = left.device
+        cache = self._get_cache(row_dim, col_dim, device, sketch_key=sketch_key)
+
+        l = self._sanitize_f32(left)
+        r = self._sanitize_f32(right)
+        sketch = torch.zeros(self.sketch_dim, device=device, dtype=torch.float32)
+        p = self._sanitize_f32(preconditioner) if preconditioner is not None else None
+
+        chunk = max(1, self.row_chunk_size)
+        for row_start in range(0, row_dim, chunk):
+            row_end = min(row_dim, row_start + chunk)
+            l_chunk = l[:, row_start:row_end]  # [N, chunk]
+
+            grad_chunk = l_chunk.transpose(0, 1).matmul(r)  # [chunk, col_dim]
+            grad_chunk = torch.nan_to_num(grad_chunk, nan=0.0, posinf=0.0, neginf=0.0)
+
+            if p is not None:
+                grad_chunk = grad_chunk * p[row_start:row_end]
+                grad_chunk = torch.nan_to_num(grad_chunk, nan=0.0, posinf=0.0, neginf=0.0)
+
+            pair_hash = (
+                cache.row_hash[row_start:row_end].unsqueeze(1) + cache.col_hash.unsqueeze(0)
+            ) % self.sketch_dim
+            pair_sign = cache.row_sign[row_start:row_end].unsqueeze(1) * cache.col_sign.unsqueeze(0)
+
+            contrib = (grad_chunk * pair_sign).reshape(-1)
+            contrib = torch.nan_to_num(contrib, nan=0.0, posinf=0.0, neginf=0.0)
+            sketch.scatter_add_(0, pair_hash.reshape(-1), contrib)
+
+        sketch = torch.nan_to_num(sketch, nan=0.0, posinf=0.0, neginf=0.0)
+        return sketch.to(out_dtype)
+
+    def project_outer_sum_pair_sample(
+        self,
+        left: torch.Tensor,
+        right_a: torch.Tensor,
+        right_b: torch.Tensor,
+        preconditioner_a: torch.Tensor | None,
+        preconditioner_b: torch.Tensor | None,
+        row_dim: int,
+        col_dim: int,
+        out_dtype: torch.dtype = torch.float32,
+        sketch_key_a: str = "",
+        sketch_key_b: str = "",
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Project two outer-sum gradients sharing the same left factors.
+
+        Useful for MoE gate/up matrices where both gradients share input activations.
+        """
+        if left.dim() != 2 or right_a.dim() != 2 or right_b.dim() != 2:
+            raise ValueError("project_outer_sum_pair_sample expects [N, D] tensors")
+        if left.shape[0] != right_a.shape[0] or left.shape[0] != right_b.shape[0]:
+            raise ValueError("left/right leading dimensions must match")
+
+        device = left.device
+        cache_a = self._get_cache(row_dim, col_dim, device, sketch_key=sketch_key_a)
+        if sketch_key_b == sketch_key_a:
+            cache_b = cache_a
+        else:
+            cache_b = self._get_cache(row_dim, col_dim, device, sketch_key=sketch_key_b)
+
+        l = self._sanitize_f32(left)
+        ra = self._sanitize_f32(right_a)
+        rb = self._sanitize_f32(right_b)
+        sketch_a = torch.zeros(self.sketch_dim, device=device, dtype=torch.float32)
+        sketch_b = torch.zeros(self.sketch_dim, device=device, dtype=torch.float32)
+        pa = self._sanitize_f32(preconditioner_a) if preconditioner_a is not None else None
+        pb = self._sanitize_f32(preconditioner_b) if preconditioner_b is not None else None
+
+        chunk = max(1, self.row_chunk_size)
+        for row_start in range(0, row_dim, chunk):
+            row_end = min(row_dim, row_start + chunk)
+            l_chunk = l[:, row_start:row_end]
+
+            grad_a = l_chunk.transpose(0, 1).matmul(ra)
+            grad_b = l_chunk.transpose(0, 1).matmul(rb)
+            grad_a = torch.nan_to_num(grad_a, nan=0.0, posinf=0.0, neginf=0.0)
+            grad_b = torch.nan_to_num(grad_b, nan=0.0, posinf=0.0, neginf=0.0)
+
+            if pa is not None:
+                grad_a = grad_a * pa[row_start:row_end]
+                grad_a = torch.nan_to_num(grad_a, nan=0.0, posinf=0.0, neginf=0.0)
+            if pb is not None:
+                grad_b = grad_b * pb[row_start:row_end]
+                grad_b = torch.nan_to_num(grad_b, nan=0.0, posinf=0.0, neginf=0.0)
+
+            pair_hash_a = (
+                cache_a.row_hash[row_start:row_end].unsqueeze(1) + cache_a.col_hash.unsqueeze(0)
+            ) % self.sketch_dim
+            pair_sign_a = cache_a.row_sign[row_start:row_end].unsqueeze(1) * cache_a.col_sign.unsqueeze(0)
+            pair_hash_b = (
+                cache_b.row_hash[row_start:row_end].unsqueeze(1) + cache_b.col_hash.unsqueeze(0)
+            ) % self.sketch_dim
+            pair_sign_b = cache_b.row_sign[row_start:row_end].unsqueeze(1) * cache_b.col_sign.unsqueeze(0)
+
+            contrib_a = (grad_a * pair_sign_a).reshape(-1)
+            contrib_b = (grad_b * pair_sign_b).reshape(-1)
+            contrib_a = torch.nan_to_num(contrib_a, nan=0.0, posinf=0.0, neginf=0.0)
+            contrib_b = torch.nan_to_num(contrib_b, nan=0.0, posinf=0.0, neginf=0.0)
+            sketch_a.scatter_add_(0, pair_hash_a.reshape(-1), contrib_a)
+            sketch_b.scatter_add_(0, pair_hash_b.reshape(-1), contrib_b)
+
+        sketch_a = torch.nan_to_num(sketch_a, nan=0.0, posinf=0.0, neginf=0.0)
+        sketch_b = torch.nan_to_num(sketch_b, nan=0.0, posinf=0.0, neginf=0.0)
+        return sketch_a.to(out_dtype), sketch_b.to(out_dtype)
+
+    def project_linear_batch(
+        self,
+        activations: torch.Tensor,
+        grad_outputs: torch.Tensor,
+        preconditioner: torch.Tensor | None,
+        out_dim: int,
+        in_dim: int,
+        out_dtype: torch.dtype = torch.float32,
+        sketch_key: str = "",
+    ) -> torch.Tensor:
+        """
+        Project batch of linear gradients to sketch vectors.
+
+        Args:
+            activations: [B, T, in_dim] or [B, in_dim]
+            grad_outputs: [B, T, out_dim] or [B, out_dim]
+            preconditioner: [out_dim, in_dim] or None
+        Returns:
+            [B, m]
+        """
+        a = self._ensure_btd(activations)
+        g = self._ensure_btd(grad_outputs)
+        if a.shape[0] != g.shape[0] or a.shape[1] != g.shape[1]:
+            raise ValueError("Batch/token dims mismatch between activations and grad_outputs")
+
+        bsz = a.shape[0]
+        out = []
+        for i in range(bsz):
+            out.append(
+                self.project_linear_sample(
+                    activations=a[i],
+                    grad_outputs=g[i],
+                    preconditioner=preconditioner,
+                    out_dim=out_dim,
+                    in_dim=in_dim,
+                    out_dtype=out_dtype,
+                    sketch_key=sketch_key,
+                )
+            )
+        return torch.stack(out, dim=0)

--- a/llm/src/llm/opus/data_selector.py
+++ b/llm/src/llm/opus/data_selector.py
@@ -111,7 +111,10 @@ class OpusDataSelector:
                     dtype=torch.bfloat16,
                 ):
                     h_score, _, _ = self.model(
-                        combined_x, return_hidden=True, return_memory=False
+                        combined_x,
+                        next_token_ids=None,  # Explicitly disable MTP for OPUS scoring (golden + raw)
+                        return_hidden=True,
+                        return_memory=False,
                     )
 
                 lm_weight = self.model.lm_head.weight

--- a/llm/src/llm/opus/data_selector.py
+++ b/llm/src/llm/opus/data_selector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import time
 import logging
-from typing import Any, Dict, Iterator, Tuple
+from typing import Any, Dict, Iterator, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -11,6 +11,7 @@ import torch.nn as nn
 from .config import OpusConfig
 from .ghost import GhostCollector
 from .preconditioner import AdamWPreconditionerView
+from .proxy import RandomInDistributionProxyProvider
 from .selector import OpusSelector
 
 logger = logging.getLogger(__name__)
@@ -30,12 +31,21 @@ class OpusDataSelector:
         config: OpusConfig,
         model: nn.Module,
         optimizer: torch.optim.Optimizer,
-        proxy_loader: Iterator,
+        proxy_loader: Union[Iterator, RandomInDistributionProxyProvider],
     ):
         self.config = config
         self.model = model  # unwrapped model (e.g. model_engine.module)
         self.optimizer = optimizer
-        self.proxy_loader = proxy_loader
+        self.proxy_provider = (
+            proxy_loader
+            if isinstance(proxy_loader, RandomInDistributionProxyProvider)
+            else None
+        )
+        self.proxy_loader = (
+            proxy_loader
+            if not isinstance(proxy_loader, RandomInDistributionProxyProvider)
+            else None
+        )
         self.selector = OpusSelector(config)
         self.preconditioner = AdamWPreconditionerView(
             optimizer, strict_shard_only=config.strict_shard_preconditioner
@@ -63,18 +73,24 @@ class OpusDataSelector:
         input_ids = candidate_batch["input_ids"].to(device)
         score_ids = input_ids[:, : cfg.score_seq_len]
 
-        # Get proxy batch from the proxy loader
-        try:
-            proxy_batch = next(self.proxy_loader)
-        except StopIteration:
-            logger.warning("Proxy loader exhausted, falling back to random")
-            indices = torch.randperm(N)[:k_select]
-            return (
-                {k: v[indices] for k, v in candidate_batch.items()},
-                {"opus_mode": "fallback_random", "opus_selected_n": k_select},
+        # Get proxy batch (provider auto-resets on epoch boundary)
+        if self.proxy_provider is not None:
+            proxy_ids = self.proxy_provider.sample(
+                device=device, k=cfg.proxy_batch_size, seq_len=cfg.score_seq_len
             )
-
-        proxy_ids = proxy_batch["input_ids"][:, : cfg.score_seq_len].to(device)
+        elif self.proxy_loader is not None:
+            try:
+                proxy_batch = next(self.proxy_loader)
+            except StopIteration:
+                logger.warning("Proxy loader exhausted, falling back to random")
+                indices = torch.randperm(N)[:k_select]
+                return (
+                    {k: v[indices] for k, v in candidate_batch.items()},
+                    {"opus_mode": "fallback_random", "opus_selected_n": k_select},
+                )
+            proxy_ids = proxy_batch["input_ids"][:, : cfg.score_seq_len].to(device)
+        else:
+            raise RuntimeError("No proxy data source configured")
 
         # Concatenate candidate + proxy for a single forward+backward pass
         combined_ids = torch.cat([score_ids, proxy_ids], dim=0)

--- a/llm/src/llm/opus/data_selector.py
+++ b/llm/src/llm/opus/data_selector.py
@@ -41,11 +41,12 @@ class OpusDataSelector:
             if isinstance(proxy_loader, RandomInDistributionProxyProvider)
             else None
         )
-        self.proxy_loader = (
-            proxy_loader
-            if not isinstance(proxy_loader, RandomInDistributionProxyProvider)
-            else None
-        )
+        if not isinstance(proxy_loader, RandomInDistributionProxyProvider):
+            self._proxy_loader_source = proxy_loader
+            self.proxy_loader = iter(proxy_loader)
+        else:
+            self._proxy_loader_source = None
+            self.proxy_loader = None
         self.selector = OpusSelector(config)
         self.preconditioner = AdamWPreconditionerView(
             optimizer, strict_shard_only=config.strict_shard_preconditioner
@@ -82,12 +83,17 @@ class OpusDataSelector:
             try:
                 proxy_batch = next(self.proxy_loader)
             except StopIteration:
-                logger.warning("Proxy loader exhausted, falling back to random")
-                indices = torch.randperm(N)[:k_select]
-                return (
-                    {k: v[indices] for k, v in candidate_batch.items()},
-                    {"opus_mode": "fallback_random", "opus_selected_n": k_select},
-                )
+                logger.info("Proxy loader exhausted — resetting iterator for next epoch")
+                try:
+                    self.proxy_loader = iter(self._proxy_loader_source)
+                    proxy_batch = next(self.proxy_loader)
+                except StopIteration:
+                    logger.warning("Proxy loader is empty after reset, falling back to random")
+                    indices = torch.randperm(N)[:k_select]
+                    return (
+                        {k: v[indices] for k, v in candidate_batch.items()},
+                        {"opus_mode": "fallback_random", "opus_selected_n": k_select},
+                    )
             proxy_ids = proxy_batch["input_ids"][:, : cfg.score_seq_len].to(device)
         else:
             raise RuntimeError("No proxy data source configured")
@@ -177,7 +183,8 @@ class OpusDataSelector:
         except Exception as e:
             if cfg.fallback_random_on_error:
                 logger.warning(
-                    f"OPUS scoring failed ({e}), falling back to random"
+                    f"OPUS scoring failed ({type(e).__name__}: {e}), falling back to random",
+                    exc_info=True,
                 )
                 selected_idx = torch.randperm(N)[:k_select]
                 self.model.zero_grad(set_to_none=True)

--- a/llm/src/llm/opus/data_selector.py
+++ b/llm/src/llm/opus/data_selector.py
@@ -1,0 +1,179 @@
+"""OpusDataSelector — composable middleware for OPUS data selection."""
+from __future__ import annotations
+
+import time
+import logging
+from typing import Any, Dict, Iterator, Tuple
+
+import torch
+import torch.nn as nn
+
+from .config import OpusConfig
+from .ghost import GhostCollector
+from .preconditioner import AdamWPreconditionerView
+from .selector import OpusSelector
+
+logger = logging.getLogger(__name__)
+
+
+class OpusDataSelector:
+    """
+    Composable middleware that sits between DataLoader and training loop.
+
+    Takes a candidate batch (N samples), runs OPUS scoring via ghost factors
+    and CountSketch features, then returns the best rho*N samples via
+    Boltzmann selection.
+    """
+
+    def __init__(
+        self,
+        config: OpusConfig,
+        model: nn.Module,
+        optimizer: torch.optim.Optimizer,
+        proxy_loader: Iterator,
+    ):
+        self.config = config
+        self.model = model  # unwrapped model (e.g. model_engine.module)
+        self.optimizer = optimizer
+        self.proxy_loader = proxy_loader
+        self.selector = OpusSelector(config)
+        self.preconditioner = AdamWPreconditionerView(
+            optimizer, strict_shard_only=config.strict_shard_preconditioner
+        )
+        self._step_count = 0
+
+    def select_batch(
+        self,
+        candidate_batch: Dict[str, torch.Tensor],
+        device: torch.device,
+    ) -> Tuple[Dict[str, torch.Tensor], Dict[str, float]]:
+        """Score candidates and return (selected_batch, metrics)."""
+        cfg = self.config
+        N = candidate_batch["input_ids"].shape[0]
+        k_select = max(1, int(N * cfg.selection_ratio))
+
+        # Random ablation mode — no scoring needed
+        if cfg.selection_mode == "random":
+            indices = torch.randperm(N)[:k_select]
+            selected = {k: v[indices] for k, v in candidate_batch.items()}
+            return selected, {"opus_mode": "random", "opus_selected_n": k_select}
+
+        # OPUS scoring mode
+        t0 = time.monotonic()
+        input_ids = candidate_batch["input_ids"].to(device)
+        score_ids = input_ids[:, : cfg.score_seq_len]
+
+        # Get proxy batch from the proxy loader
+        try:
+            proxy_batch = next(self.proxy_loader)
+        except StopIteration:
+            logger.warning("Proxy loader exhausted, falling back to random")
+            indices = torch.randperm(N)[:k_select]
+            return (
+                {k: v[indices] for k, v in candidate_batch.items()},
+                {"opus_mode": "fallback_random", "opus_selected_n": k_select},
+            )
+
+        proxy_ids = proxy_batch["input_ids"][:, : cfg.score_seq_len].to(device)
+
+        # Concatenate candidate + proxy for a single forward+backward pass
+        combined_ids = torch.cat([score_ids, proxy_ids], dim=0)
+        combined_x = combined_ids[:, :-1]
+        combined_y = combined_ids[:, 1:]
+
+        try:
+            self.model.zero_grad(set_to_none=True)
+
+            with GhostCollector(
+                self.model,
+                include_embeddings=cfg.include_embeddings,
+                include_lm_head=cfg.include_lm_head,
+            ) as collector:
+                with torch.amp.autocast(
+                    "cuda",
+                    enabled=torch.cuda.is_available(),
+                    dtype=torch.bfloat16,
+                ):
+                    h_score, _, _ = self.model(
+                        combined_x, return_hidden=True, return_memory=False
+                    )
+
+                lm_weight = self.model.lm_head.weight
+                H_dim = h_score.shape[-1]
+                score_logits = torch.nn.functional.linear(
+                    h_score.view(-1, H_dim), lm_weight
+                )
+                score_loss = torch.nn.functional.cross_entropy(
+                    score_logits, combined_y.reshape(-1), ignore_index=-100
+                )
+                score_loss.backward()
+
+                captures = collector.captures()
+                moe_captures = collector.moe_captures()
+
+            # Build sketch features using the real API
+            n_candidates = score_ids.shape[0]
+            n_proxy = proxy_ids.shape[0]
+
+            c_feats, p_feats = self.selector.build_sketch_features(
+                captures=captures,
+                candidate_count=n_candidates,
+                proxy_count=n_proxy,
+                preconditioner=self.preconditioner,
+                moe_captures=moe_captures if moe_captures else None,
+            )
+
+            lr = (
+                self.optimizer.param_groups[0].get("lr", 1e-3)
+                if self.optimizer.param_groups
+                else 1e-3
+            )
+
+            # select() uses config.selection_ratio internally, no n_select param
+            selection = self.selector.select(
+                candidate_features=c_feats,
+                proxy_features=p_feats,
+                learning_rate=lr,
+            )
+
+            selected_idx = selection.selected_local_indices.cpu()
+            self.model.zero_grad(set_to_none=True)
+
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            metrics: Dict[str, Any] = {
+                "opus_mode": "opus",
+                "opus_alignment": selection.metrics.get("alignment", 0.0),
+                "opus_redundancy": selection.metrics.get("redundancy", 0.0),
+                "opus_entropy": selection.metrics.get("entropy", 0.0),
+                "opus_selected_n": int(selected_idx.numel()),
+                "opus_candidates_n": N,
+                "opus_overhead_ms": elapsed_ms,
+                "opus_used_fallback": selection.used_fallback,
+            }
+            if cfg.track_nonfinite_stats:
+                metrics["opus_nonfinite_count"] = selection.metrics.get(
+                    "nonfinite_feature_values", 0
+                )
+
+        except Exception as e:
+            if cfg.fallback_random_on_error:
+                logger.warning(
+                    f"OPUS scoring failed ({e}), falling back to random"
+                )
+                selected_idx = torch.randperm(N)[:k_select]
+                self.model.zero_grad(set_to_none=True)
+                metrics = {
+                    "opus_mode": "fallback_random",
+                    "opus_error": str(e),
+                    "opus_selected_n": k_select,
+                }
+            else:
+                raise
+
+        selected_batch = {k: v[selected_idx] for k, v in candidate_batch.items()}
+        self._step_count += 1
+        return selected_batch, metrics
+
+    def refresh_preconditioner(self) -> None:
+        """Refresh cached preconditioner values (call after optimizer step)."""
+        self.preconditioner.refresh()

--- a/llm/src/llm/opus/distributed.py
+++ b/llm/src/llm/opus/distributed.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import random
+from typing import Optional
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+
+
+def distributed_available() -> bool:
+    return dist.is_available() and dist.is_initialized()
+
+
+
+def get_rank() -> int:
+    return dist.get_rank() if distributed_available() else 0
+
+
+
+def get_world_size() -> int:
+    return dist.get_world_size() if distributed_available() else 1
+
+
+
+def is_rank0() -> bool:
+    return get_rank() == 0
+
+
+
+def set_seed(seed: int) -> None:
+    rank = get_rank()
+    seed_rank = int(seed) + rank
+    random.seed(seed_rank)
+    np.random.seed(seed_rank)
+    torch.manual_seed(seed_rank)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed_rank)
+
+
+
+def init_distributed(timeout_minutes: int = 30) -> None:
+    if distributed_available():
+        return
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        return
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    dist.init_process_group(
+        backend=backend,
+        timeout=_dt.timedelta(minutes=timeout_minutes),
+    )
+
+
+
+def barrier() -> None:
+    if distributed_available():
+        dist.barrier()
+
+
+
+def all_reduce_sum(tensor: torch.Tensor) -> torch.Tensor:
+    if distributed_available():
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM)
+    return tensor
+
+
+def all_reduce_sum_async(tensor: torch.Tensor):
+    if distributed_available():
+        return dist.all_reduce(tensor, op=dist.ReduceOp.SUM, async_op=True)
+    return None
+
+
+
+def all_reduce_max(tensor: torch.Tensor) -> torch.Tensor:
+    if distributed_available():
+        dist.all_reduce(tensor, op=dist.ReduceOp.MAX)
+    return tensor
+
+
+
+def broadcast_tensor(tensor: torch.Tensor, src: int = 0) -> torch.Tensor:
+    if distributed_available():
+        dist.broadcast(tensor, src=src)
+    return tensor
+
+
+
+def all_gather_1d(local: torch.Tensor) -> torch.Tensor:
+    if local.dim() != 1:
+        raise ValueError(f"Expected 1D tensor, got shape {tuple(local.shape)}")
+    if not distributed_available():
+        return local
+    parts = [torch.empty_like(local) for _ in range(get_world_size())]
+    dist.all_gather(parts, local)
+    return torch.cat(parts, dim=0)

--- a/llm/src/llm/opus/ghost.py
+++ b/llm/src/llm/opus/ghost.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import torch
+import torch.nn as nn
+
+
+@dataclass
+class LayerCapture:
+    name: str
+    module: nn.Module
+    weight: torch.nn.Parameter
+    activations: torch.Tensor
+    grad_outputs: torch.Tensor
+
+
+@dataclass
+class MoERoutedCapture:
+    name: str
+    module: nn.Module
+    w_gate: torch.nn.Parameter
+    w_up: torch.nn.Parameter
+    w_down: torch.nn.Parameter
+    activations: torch.Tensor
+    grad_outputs: torch.Tensor
+    topk_idx: torch.Tensor
+    topk_weight: torch.Tensor
+    is_null: torch.Tensor
+
+
+class GhostCollector:
+    """
+    Collects per-sample activations and output gradients for linear layers.
+
+    Intended for OPUS scoring pass where a single backward captures candidate and
+    proxy ghost factors without per-sample backward loops.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        include_embeddings: bool = False,
+        include_lm_head: bool = False,
+    ):
+        self.model = model
+        self.include_embeddings = include_embeddings
+        self.include_lm_head = include_lm_head
+        self._handles: List[torch.utils.hooks.RemovableHandle] = []
+        self._selected: Dict[str, nn.Module] = {}
+        self._selected_moe: Dict[str, nn.Module] = {}
+        self._activations: Dict[str, torch.Tensor] = {}
+        self._grad_outputs: Dict[str, torch.Tensor] = {}
+        self._moe_activations: Dict[str, torch.Tensor] = {}
+        self._moe_grad_outputs: Dict[str, torch.Tensor] = {}
+        self._moe_routing: Dict[str, Dict[str, torch.Tensor]] = {}
+
+    def _should_track(self, name: str, module: nn.Module) -> bool:
+        if isinstance(module, nn.Linear):
+            # Default: all linears inside transformer blocks.
+            in_blocks = ("layers." in name) or ("blocks." in name)
+            if in_blocks:
+                return True
+            if self.include_lm_head and name.endswith("lm_head"):
+                return True
+            return False
+        if self.include_embeddings and isinstance(module, nn.Embedding):
+            return True
+        return False
+
+    @staticmethod
+    def _is_moe_module(module: nn.Module) -> bool:
+        w_gate = getattr(module, "W_gate", None)
+        w_up = getattr(module, "W_up", None)
+        w_down = getattr(module, "W_down", None)
+        if not isinstance(w_gate, torch.nn.Parameter):
+            return False
+        if not isinstance(w_up, torch.nn.Parameter):
+            return False
+        if not isinstance(w_down, torch.nn.Parameter):
+            return False
+        return (w_gate.dim() == 3) and (w_up.dim() == 3) and (w_down.dim() == 3)
+
+    def _should_track_moe(self, name: str, module: nn.Module) -> bool:
+        in_blocks = ("layers." in name) or ("blocks." in name)
+        return in_blocks and self._is_moe_module(module)
+
+    def discover_layers(self) -> Dict[str, nn.Module]:
+        layers: Dict[str, nn.Module] = {}
+        for name, module in self.model.named_modules():
+            if self._should_track(name, module):
+                if getattr(module, "weight", None) is not None and module.weight.dim() == 2:
+                    layers[name] = module
+        if not layers:
+            raise RuntimeError("GhostCollector found zero scoreable layers")
+        self._selected = layers
+        return layers
+
+    def discover_moe_layers(self) -> Dict[str, nn.Module]:
+        layers: Dict[str, nn.Module] = {}
+        for name, module in self.model.named_modules():
+            if self._should_track_moe(name, module):
+                layers[name] = module
+        self._selected_moe = layers
+        return layers
+
+    def clear(self) -> None:
+        self._activations.clear()
+        self._grad_outputs.clear()
+        self._moe_activations.clear()
+        self._moe_grad_outputs.clear()
+        self._moe_routing.clear()
+
+    def register(self) -> None:
+        if not self._selected:
+            self.discover_layers()
+        self.discover_moe_layers()
+        self.clear()
+
+        def _make_fwd(name: str):
+            def _fwd(module: nn.Module, args: Tuple[torch.Tensor, ...], output: torch.Tensor):
+                if not args:
+                    return
+                x = args[0]
+                if not torch.is_tensor(x):
+                    return
+                self._activations[name] = x.detach()
+
+            return _fwd
+
+        def _make_bwd(name: str):
+            def _bwd(module: nn.Module, grad_input, grad_output):
+                if not grad_output:
+                    return
+                gout = grad_output[0]
+                if not torch.is_tensor(gout):
+                    return
+                self._grad_outputs[name] = gout.detach()
+
+            return _bwd
+
+        def _make_moe_fwd(name: str):
+            def _fwd(module: nn.Module, args: Tuple[torch.Tensor, ...], output):
+                if not args:
+                    return
+                x = args[0]
+                if not torch.is_tensor(x):
+                    return
+                routing = getattr(module, "last_routing", None)
+                if routing is None:
+                    return
+                topk_idx = routing.get("topk_idx")
+                topk_weight = routing.get("topk_weight")
+                is_null = routing.get("is_null")
+                if not (torch.is_tensor(topk_idx) and torch.is_tensor(topk_weight) and torch.is_tensor(is_null)):
+                    return
+                self._moe_activations[name] = x.detach()
+                self._moe_routing[name] = {
+                    "topk_idx": topk_idx.detach(),
+                    "topk_weight": topk_weight.detach(),
+                    "is_null": is_null.detach(),
+                }
+
+            return _fwd
+
+        def _make_moe_bwd(name: str):
+            def _bwd(module: nn.Module, grad_input, grad_output):
+                if not grad_output:
+                    return
+                gout = grad_output[0]
+                if not torch.is_tensor(gout):
+                    return
+                self._moe_grad_outputs[name] = gout.detach()
+
+            return _bwd
+
+        for name, module in self._selected.items():
+            self._handles.append(module.register_forward_hook(_make_fwd(name)))
+            self._handles.append(module.register_full_backward_hook(_make_bwd(name)))
+        for name, module in self._selected_moe.items():
+            self._handles.append(module.register_forward_hook(_make_moe_fwd(name)))
+            self._handles.append(module.register_full_backward_hook(_make_moe_bwd(name)))
+
+    def unregister(self) -> None:
+        while self._handles:
+            h = self._handles.pop()
+            h.remove()
+
+    def captures(self) -> Dict[str, LayerCapture]:
+        out: Dict[str, LayerCapture] = {}
+        for name, module in self._selected.items():
+            if name not in self._activations or name not in self._grad_outputs:
+                continue
+            act = self._activations.pop(name)
+            gout = self._grad_outputs.pop(name)
+            out[name] = LayerCapture(
+                name=name,
+                module=module,
+                weight=module.weight,
+                activations=act,
+                grad_outputs=gout,
+            )
+        if not out:
+            raise RuntimeError("GhostCollector has no captured activations/gradients")
+        return out
+
+    def moe_captures(self) -> Dict[str, MoERoutedCapture]:
+        out: Dict[str, MoERoutedCapture] = {}
+        for name, module in self._selected_moe.items():
+            if name not in self._moe_activations or name not in self._moe_grad_outputs or name not in self._moe_routing:
+                continue
+            act = self._moe_activations.pop(name)
+            gout = self._moe_grad_outputs.pop(name)
+            routing = self._moe_routing.pop(name)
+            out[name] = MoERoutedCapture(
+                name=name,
+                module=module,
+                w_gate=module.W_gate,
+                w_up=module.W_up,
+                w_down=module.W_down,
+                activations=act,
+                grad_outputs=gout,
+                topk_idx=routing["topk_idx"],
+                topk_weight=routing["topk_weight"],
+                is_null=routing["is_null"],
+            )
+        return out
+
+    def __enter__(self) -> "GhostCollector":
+        self.register()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.unregister()
+        self.clear()

--- a/llm/src/llm/opus/ghost.py
+++ b/llm/src/llm/opus/ghost.py
@@ -125,7 +125,7 @@ class GhostCollector:
                 x = args[0]
                 if not torch.is_tensor(x):
                     return
-                self._activations[name] = x.detach()
+                self._activations[name] = x.detach().clone()
 
             return _fwd
 
@@ -136,7 +136,7 @@ class GhostCollector:
                 gout = grad_output[0]
                 if not torch.is_tensor(gout):
                     return
-                self._grad_outputs[name] = gout.detach()
+                self._grad_outputs[name] = gout.detach().clone()
 
             return _bwd
 
@@ -155,11 +155,11 @@ class GhostCollector:
                 is_null = routing.get("is_null")
                 if not (torch.is_tensor(topk_idx) and torch.is_tensor(topk_weight) and torch.is_tensor(is_null)):
                     return
-                self._moe_activations[name] = x.detach()
+                self._moe_activations[name] = x.detach().clone()
                 self._moe_routing[name] = {
-                    "topk_idx": topk_idx.detach(),
-                    "topk_weight": topk_weight.detach(),
-                    "is_null": is_null.detach(),
+                    "topk_idx": topk_idx.detach().clone(),
+                    "topk_weight": topk_weight.detach().clone(),
+                    "is_null": is_null.detach().clone(),
                 }
 
             return _fwd
@@ -171,7 +171,7 @@ class GhostCollector:
                 gout = grad_output[0]
                 if not torch.is_tensor(gout):
                     return
-                self._moe_grad_outputs[name] = gout.detach()
+                self._moe_grad_outputs[name] = gout.detach().clone()
 
             return _bwd
 

--- a/llm/src/llm/opus/preconditioner.py
+++ b/llm/src/llm/opus/preconditioner.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Dict, Optional
+
+import torch
+
+
+@dataclass
+class _GroupHyper:
+    lr: float
+    beta1: float
+    beta2: float
+    eps: float
+
+
+class AdamWPreconditionerView:
+    """
+    Frozen, read-only AdamW preconditioner view for the current step.
+
+    P_t = C_t * diag(1 / (sqrt(v_hat) + eps))
+    C_t = lr * (1 - beta1) / (1 - beta1^step)
+
+    If optimizer state is unavailable for a parameter (possible with some sharded
+    implementations), this view falls back to a scalar C_t identity scaling.
+    """
+
+    def __init__(self, optimizer: torch.optim.Optimizer, strict_shard_only: bool = False):
+        self.optimizer = optimizer
+        self.strict_shard_only = bool(strict_shard_only)
+        self._param_to_group: Dict[int, _GroupHyper] = {}
+        self._build_group_index()
+        self._cache: Dict[int, torch.Tensor] = {}
+        self._slice_cache: Dict[tuple[int, int], torch.Tensor] = {}
+
+    @classmethod
+    def from_deepspeed(cls, model_engine, strict_shard_only: bool = False):
+        """Create preconditioner from a DeepSpeed model engine."""
+        ds_optimizer = model_engine.optimizer
+        base_optimizer = getattr(ds_optimizer, "optimizer", ds_optimizer)
+        view = cls(base_optimizer, strict_shard_only=strict_shard_only)
+        view._model_engine = model_engine
+        return view
+
+    def _build_group_index(self) -> None:
+        self._param_to_group.clear()
+        for group in self.optimizer.param_groups:
+            lr = float(group.get("lr", 1e-3))
+            betas = group.get("betas", (0.9, 0.999))
+            eps = float(group.get("eps", 1e-8))
+            gh = _GroupHyper(lr=lr, beta1=float(betas[0]), beta2=float(betas[1]), eps=eps)
+            for p in group["params"]:
+                self._param_to_group[id(p)] = gh
+
+    def refresh(self) -> None:
+        self._build_group_index()
+        self._cache.clear()
+        self._slice_cache.clear()
+
+    def _scalar_fallback(self, p: torch.nn.Parameter) -> torch.Tensor:
+        if self.strict_shard_only:
+            return torch.zeros_like(p.data, dtype=torch.float32)
+        gh = self._param_to_group.get(id(p), None)
+        if gh is None:
+            return torch.ones_like(p.data, dtype=torch.float32)
+        return torch.full_like(p.data, fill_value=gh.lr * (1.0 - gh.beta1), dtype=torch.float32)
+
+    def _scalar_fallback_like(self, p: torch.nn.Parameter, ref: torch.Tensor) -> torch.Tensor:
+        if self.strict_shard_only:
+            return torch.zeros_like(ref, dtype=torch.float32)
+        gh = self._param_to_group.get(id(p), None)
+        if gh is None:
+            return torch.ones_like(ref, dtype=torch.float32)
+        return torch.full_like(ref, fill_value=gh.lr * (1.0 - gh.beta1), dtype=torch.float32)
+
+    @staticmethod
+    def _resolve_step(step) -> float:
+        if torch.is_tensor(step):
+            step_f = float(step.item())
+        elif step is None:
+            step_f = 1.0
+        else:
+            step_f = float(step)
+        if not math.isfinite(step_f):
+            step_f = 1.0
+        return max(step_f, 1.0)
+
+    @staticmethod
+    def _corrections(gh: _GroupHyper, step_f: float) -> tuple[float, float]:
+        bias_correction1 = 1.0 - (gh.beta1 ** step_f)
+        bias_correction2 = 1.0 - (gh.beta2 ** step_f)
+        c_t = gh.lr * (1.0 - gh.beta1) / max(bias_correction1, 1e-12)
+        return c_t, bias_correction2
+
+    def _finite_or_fallback(self, p: torch.nn.Parameter, out: torch.Tensor) -> torch.Tensor:
+        if out.shape != p.data.shape:
+            return self._scalar_fallback(p)
+        if not bool(torch.isfinite(out).all()):
+            return self._scalar_fallback(p)
+        return out
+
+    def get(self, p: torch.nn.Parameter) -> torch.Tensor:
+        pid = id(p)
+        if pid in self._cache:
+            return self._cache[pid]
+
+        gh = self._param_to_group.get(pid)
+        if gh is None:
+            out = torch.zeros_like(p.data, dtype=torch.float32) if self.strict_shard_only else torch.ones_like(p.data, dtype=torch.float32)
+            self._cache[pid] = out
+            return out
+
+        state = self.optimizer.state.get(p, None)
+        if not state:
+            out = self._scalar_fallback(p)
+            self._cache[pid] = out
+            return out
+
+        exp_avg_sq = state.get("exp_avg_sq", None)
+        step = state.get("step", None)
+        if exp_avg_sq is None:
+            out = self._scalar_fallback(p)
+            self._cache[pid] = out
+            return out
+
+        step_f = self._resolve_step(step)
+        c_t, bias_correction2 = self._corrections(gh, step_f)
+
+        v_hat = exp_avg_sq.to(torch.float32) / max(bias_correction2, 1e-12)
+        v_hat = torch.nan_to_num(v_hat, nan=0.0, posinf=0.0, neginf=0.0).clamp_min_(0.0)
+        out = c_t / (torch.sqrt(v_hat) + gh.eps)
+        out = self._finite_or_fallback(p, out)
+
+        self._cache[pid] = out
+        return out
+
+    def get_slice(self, p: torch.nn.Parameter, index) -> torch.Tensor:
+        """
+        Return a preconditioner slice for `p[index]` without materializing full tensor preconditioner.
+        Falls back to scalar C_t scaling if optimizer state is unavailable or incompatible.
+        """
+        if torch.is_tensor(index):
+            idx_int = int(index.item())
+        else:
+            idx_int = int(index)
+        key = (id(p), idx_int)
+        if key in self._slice_cache:
+            return self._slice_cache[key]
+
+        ref = p.data[index]
+        gh = self._param_to_group.get(id(p), None)
+        if gh is None:
+            out = torch.zeros_like(ref, dtype=torch.float32) if self.strict_shard_only else torch.ones_like(ref, dtype=torch.float32)
+            self._slice_cache[key] = out
+            return out
+
+        state = self.optimizer.state.get(p, None)
+        if not state:
+            out = self._scalar_fallback_like(p, ref)
+            self._slice_cache[key] = out
+            return out
+
+        exp_avg_sq = state.get("exp_avg_sq", None)
+        step = state.get("step", None)
+        if exp_avg_sq is None:
+            out = self._scalar_fallback_like(p, ref)
+            self._slice_cache[key] = out
+            return out
+
+        try:
+            exp_avg_sq_slice = exp_avg_sq[index]
+        except Exception:
+            out = self._scalar_fallback_like(p, ref)
+            self._slice_cache[key] = out
+            return out
+
+        step_f = self._resolve_step(step)
+        c_t, bias_correction2 = self._corrections(gh, step_f)
+
+        v_hat = exp_avg_sq_slice.to(torch.float32) / max(bias_correction2, 1e-12)
+        v_hat = torch.nan_to_num(v_hat, nan=0.0, posinf=0.0, neginf=0.0).clamp_min_(0.0)
+        out = c_t / (torch.sqrt(v_hat) + gh.eps)
+
+        if out.shape != ref.shape or not bool(torch.isfinite(out).all()):
+            out = self._scalar_fallback_like(p, ref)
+        self._slice_cache[key] = out
+        return out
+
+    def get_slices(self, p: torch.nn.Parameter, indices: torch.Tensor) -> torch.Tensor:
+        """
+        Batched slice accessor for expert-indexed tensors.
+        Returns tensor of shape [len(indices), *p.shape[1:]] in float32.
+        """
+        if indices.dim() != 1:
+            raise ValueError(f"indices must be 1D, got shape={tuple(indices.shape)}")
+        if indices.numel() == 0:
+            return torch.empty((0, *p.shape[1:]), device=p.device, dtype=torch.float32)
+
+        out = []
+        for i in indices.tolist():
+            out.append(self.get_slice(p, int(i)))
+        return torch.stack(out, dim=0)

--- a/llm/src/llm/opus/proxy.py
+++ b/llm/src/llm/opus/proxy.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Iterator, Optional, Dict, Any
+
+import torch
+from torch.utils.data import DataLoader
+
+
+class ProxyProvider(ABC):
+    @abstractmethod
+    def sample(self, device: torch.device, k: int, seq_len: int) -> torch.Tensor:
+        raise NotImplementedError
+
+    @abstractmethod
+    def state_dict(self) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def load_state_dict(self, state: Dict[str, Any]) -> None:
+        raise NotImplementedError
+
+
+class RandomInDistributionProxyProvider(ProxyProvider):
+    """
+    Stage-A proxy provider using an independent in-distribution stream.
+    """
+
+    def __init__(self, loader: DataLoader):
+        self.loader = loader
+        self._iter: Iterator = iter(loader)
+        self._seen = 0
+
+    def _next_batch(self) -> Dict[str, torch.Tensor]:
+        try:
+            batch = next(self._iter)
+        except StopIteration:
+            self._iter = iter(self.loader)
+            batch = next(self._iter)
+        return batch
+
+    def sample(self, device: torch.device, k: int, seq_len: int) -> torch.Tensor:
+        chunks = []
+        while sum(x.size(0) for x in chunks) < k:
+            batch = self._next_batch()
+            x = batch["input_ids"]
+            assert x.size(1) >= seq_len, (
+                f"Proxy stream returned sequence length {x.size(1)} < expected {seq_len}. "
+                f"All sequences must be exactly {seq_len} tokens — no padding."
+            )
+            x = x[:, :seq_len]
+            chunks.append(x)
+        out = torch.cat(chunks, dim=0)[:k]
+        self._seen += int(k)
+        return out.to(device, non_blocking=True)
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {"seen": self._seen}
+
+    def load_state_dict(self, state: Dict[str, Any]) -> None:
+        self._seen = int(state.get("seen", 0))
+
+
+class BenchProxyProvider(ProxyProvider):
+    """
+    Stage-B proxy provider backed by a benchmark-retrieved token shard.
+
+    Expected format is a torch tensor file with shape [N, L] of tokenized sequences.
+    """
+
+    def __init__(self, token_tensor_path: str):
+        self.token_tensor_path = token_tensor_path
+        self.tokens = torch.load(token_tensor_path, map_location="cpu")
+        if not torch.is_tensor(self.tokens) or self.tokens.dim() != 2:
+            raise ValueError("BenchProxyProvider expects a [N, L] token tensor")
+        self._seen = 0
+
+    def sample(self, device: torch.device, k: int, seq_len: int) -> torch.Tensor:
+        if self.tokens.size(0) == 0:
+            raise RuntimeError("Bench proxy shard is empty")
+        assert self.tokens.size(1) >= seq_len, (
+            f"Bench proxy shard has sequence length {self.tokens.size(1)} < expected {seq_len}. "
+            f"All sequences must be exactly {seq_len} tokens — no padding."
+        )
+        idxs = torch.randint(0, self.tokens.size(0), (k,))
+        rows = self.tokens[idxs][:, :seq_len]
+        self._seen += k
+        return rows.to(device, non_blocking=True)
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {"seen": self._seen, "path": self.token_tensor_path}
+
+    def load_state_dict(self, state: Dict[str, Any]) -> None:
+        self._seen = int(state.get("seen", 0))

--- a/llm/src/llm/opus/selector.py
+++ b/llm/src/llm/opus/selector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import math
 import time
 from dataclasses import dataclass
@@ -20,6 +21,8 @@ from .distributed import (
 from .countsketch import CountSketchProjector
 from .ghost import LayerCapture, MoERoutedCapture
 from .preconditioner import AdamWPreconditionerView
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -550,8 +553,21 @@ class OpusSelector:
                 redundancy = torch.einsum("nlm,lm->n", cand, history)
                 local_scores = (learning_rate * alignment) - (learning_rate * learning_rate * redundancy)
                 local_scores = local_scores.to(torch.float32)
+                _n_nonfinite = int((~torch.isfinite(local_scores)).sum().item())
                 if self._track_nonfinite:
-                    nonfinite_local_scores += float((~torch.isfinite(local_scores)).sum().item())
+                    nonfinite_local_scores += float(_n_nonfinite)
+                if _n_nonfinite == local_scores.numel() and local_scores.numel() > 0:
+                    logger.warning(
+                        "OPUS selector: all %d candidate scores are non-finite "
+                        "— selection is effectively random this step",
+                        local_scores.numel(),
+                    )
+                elif _n_nonfinite > 0:
+                    logger.warning(
+                        "OPUS selector: %d/%d scores are non-finite",
+                        _n_nonfinite,
+                        local_scores.numel(),
+                    )
                 local_scores = torch.nan_to_num(
                     local_scores,
                     nan=torch.finfo(torch.float32).min,

--- a/llm/src/llm/opus/selector.py
+++ b/llm/src/llm/opus/selector.py
@@ -1,0 +1,697 @@
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Tuple, Any, Optional
+
+import torch
+
+from .config import OpusConfig
+from .distributed import (
+    get_rank,
+    get_world_size,
+    all_gather_1d,
+    broadcast_tensor,
+    all_reduce_sum,
+    all_reduce_sum_async,
+    all_reduce_max,
+)
+from .countsketch import CountSketchProjector
+from .ghost import LayerCapture, MoERoutedCapture
+from .preconditioner import AdamWPreconditionerView
+
+
+@dataclass
+class SelectionResult:
+    selected_local_indices: torch.Tensor
+    selected_global_indices: torch.Tensor
+    used_fallback: bool
+    metrics: Dict[str, float]
+
+
+class OpusSelector:
+    """
+    AdamW-only OPUS selector using ghost factors + CountSketch features.
+    """
+
+    def __init__(self, config: OpusConfig):
+        self.config = config
+        self.projector = CountSketchProjector(
+            sketch_dim=config.sketch_dim,
+            seed=config.sketch_seed,
+        )
+        self._rng = torch.Generator(device="cpu")
+        self._rng.manual_seed(int(config.sketch_seed))
+        self._last_feature_stats: Dict[str, float] = {}
+        self._track_nonfinite = bool(getattr(config, "track_nonfinite_stats", True))
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {
+            "rng_state": self._rng.get_state(),
+            "config": {
+                "candidate_multiplier": self.config.candidate_multiplier,
+                "selection_ratio": self.config.selection_ratio,
+                "score_seq_len": self.config.score_seq_len,
+                "proxy_batch_size": self.config.proxy_batch_size,
+                "sketch_dim": self.config.sketch_dim,
+                "temperature": self.config.temperature,
+                "sketch_seed": self.config.sketch_seed,
+            },
+        }
+
+    def load_state_dict(self, state: Dict[str, Any]) -> None:
+        if "rng_state" in state:
+            self._rng.set_state(state["rng_state"])
+
+    @staticmethod
+    def _ensure_btd(x: torch.Tensor) -> torch.Tensor:
+        if x.dim() == 3:
+            return x
+        if x.dim() == 2:
+            return x.unsqueeze(1)
+        raise ValueError(f"Expected dim 2/3 tensor, got shape {tuple(x.shape)}")
+
+    def _sanitize_for_scoring(self, x: torch.Tensor) -> Tuple[torch.Tensor, int]:
+        bad = int((~torch.isfinite(x)).sum().item()) if self._track_nonfinite else 0
+        x = torch.nan_to_num(x.to(torch.float32), nan=0.0, posinf=0.0, neginf=0.0)
+        return x, bad
+
+    @staticmethod
+    def _silu_prime(x: torch.Tensor) -> torch.Tensor:
+        sig = torch.sigmoid(x)
+        return sig * (1.0 + x * (1.0 - sig))
+
+    def _build_moe_features(
+        self,
+        moe_captures: Dict[str, MoERoutedCapture],
+        candidate_count: int,
+        proxy_count: int,
+        preconditioner: AdamWPreconditionerView,
+        out_dtype: torch.dtype,
+    ) -> Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor], Dict[str, float]]:
+        candidate_features: Dict[str, torch.Tensor] = {}
+        proxy_features: Dict[str, torch.Tensor] = {}
+
+        total_bad_act = 0.0
+        total_bad_grad = 0.0
+        total_bad_precond = 0.0
+
+        for layer_name, cap in list(moe_captures.items()):
+            x_all, bad_x = self._sanitize_for_scoring(self._ensure_btd(cap.activations))
+            dy_all, bad_dy = self._sanitize_for_scoring(self._ensure_btd(cap.grad_outputs))
+            topk_idx = cap.topk_idx
+            topk_weight, bad_w = self._sanitize_for_scoring(cap.topk_weight)
+            is_null = cap.is_null
+
+            total_bad_act += float(bad_x)
+            total_bad_grad += float(bad_dy + bad_w)
+
+            if x_all.shape[0] < candidate_count + proxy_count:
+                raise RuntimeError(
+                    f"MoE layer {layer_name} captured batch too small: {x_all.shape[0]} < {candidate_count + proxy_count}"
+                )
+
+            x_cand = x_all[:candidate_count]
+            dy_cand = dy_all[:candidate_count]
+            idx_cand = topk_idx[:candidate_count]
+            w_cand = topk_weight[:candidate_count]
+            null_cand = is_null[:candidate_count]
+
+            x_proxy = x_all[candidate_count:candidate_count + proxy_count]
+            dy_proxy = dy_all[candidate_count:candidate_count + proxy_count]
+            idx_proxy = topk_idx[candidate_count:candidate_count + proxy_count]
+            w_proxy = topk_weight[candidate_count:candidate_count + proxy_count]
+            null_proxy = is_null[candidate_count:candidate_count + proxy_count]
+
+            feat_gate_c = torch.zeros(candidate_count, self.config.sketch_dim, device=x_all.device, dtype=out_dtype)
+            feat_up_c = torch.zeros_like(feat_gate_c)
+            feat_down_c = torch.zeros_like(feat_gate_c)
+            feat_gate_p = torch.zeros(proxy_count, self.config.sketch_dim, device=x_all.device, dtype=out_dtype)
+            feat_up_p = torch.zeros_like(feat_gate_p)
+            feat_down_p = torch.zeros_like(feat_gate_p)
+
+            wg_cache: Dict[int, torch.Tensor] = {}
+            wu_cache: Dict[int, torch.Tensor] = {}
+            wd_cache: Dict[int, torch.Tensor] = {}
+            wg_weight_cache: Dict[int, torch.Tensor] = {}
+            wu_weight_cache: Dict[int, torch.Tensor] = {}
+            wd_weight_cache: Dict[int, torch.Tensor] = {}
+
+            def _fetch_precond(cache: Dict[int, torch.Tensor], param: torch.nn.Parameter, expert_idx: int) -> torch.Tensor:
+                nonlocal total_bad_precond
+                if expert_idx not in cache:
+                    p_raw = preconditioner.get_slice(param, expert_idx)
+                    p, bad = self._sanitize_for_scoring(p_raw)
+                    cache[expert_idx] = p
+                    total_bad_precond += float(bad)
+                return cache[expert_idx]
+
+            def _fetch_weight(cache: Dict[int, torch.Tensor], param: torch.nn.Parameter, expert_idx: int) -> torch.Tensor:
+                nonlocal total_bad_precond
+                if expert_idx not in cache:
+                    w_raw = param[expert_idx]
+                    w, bad = self._sanitize_for_scoring(w_raw)
+                    cache[expert_idx] = w
+                    total_bad_precond += float(bad)
+                return cache[expert_idx]
+
+            # Bulk prefetch active expert preconditioner slices and weights once per layer.
+            active_ids: List[int] = []
+            if bool((~null_cand).any()):
+                active_ids.extend(idx_cand[~null_cand].to(torch.long).unique().tolist())
+            if bool((~null_proxy).any()):
+                active_ids.extend(idx_proxy[~null_proxy].to(torch.long).unique().tolist())
+            if active_ids:
+                active_unique = torch.tensor(sorted(set(int(x) for x in active_ids)), device=x_all.device, dtype=torch.long)
+                p_wg_all = preconditioner.get_slices(cap.w_gate, active_unique)
+                p_wu_all = preconditioner.get_slices(cap.w_up, active_unique)
+                p_wd_all = preconditioner.get_slices(cap.w_down, active_unique)
+                for j, e_val in enumerate(active_unique.tolist()):
+                    e = int(e_val)
+                    p_wg, bad_wg = self._sanitize_for_scoring(p_wg_all[j])
+                    p_wu, bad_wu = self._sanitize_for_scoring(p_wu_all[j])
+                    p_wd, bad_wd = self._sanitize_for_scoring(p_wd_all[j])
+                    wg_cache[e] = p_wg
+                    wu_cache[e] = p_wu
+                    wd_cache[e] = p_wd
+                    total_bad_precond += float(bad_wg + bad_wu + bad_wd)
+                    wg_w, bad_wgw = self._sanitize_for_scoring(cap.w_gate[e])
+                    wu_w, bad_wuw = self._sanitize_for_scoring(cap.w_up[e])
+                    wd_w, bad_wdw = self._sanitize_for_scoring(cap.w_down[e])
+                    wg_weight_cache[e] = wg_w
+                    wu_weight_cache[e] = wu_w
+                    wd_weight_cache[e] = wd_w
+                    total_bad_precond += float(bad_wgw + bad_wuw + bad_wdw)
+
+            def _accumulate_partition(
+                x_part: torch.Tensor,
+                dy_part: torch.Tensor,
+                idx_part: torch.Tensor,
+                w_part: torch.Tensor,
+                null_part: torch.Tensor,
+                out_gate: torch.Tensor,
+                out_up: torch.Tensor,
+                out_down: torch.Tensor,
+            ) -> None:
+                nonlocal total_bad_grad
+                bsz, seq_len, _ = x_part.shape
+                if bsz == 0:
+                    return
+
+                # Flatten routed assignments once, then process expert groups.
+                k_slots = idx_part.shape[-1]
+                sample_ids_full = torch.arange(bsz, device=x_part.device, dtype=torch.long).view(bsz, 1, 1)
+                sample_ids_full = sample_ids_full.expand(bsz, seq_len, k_slots)
+                token_ids_full = torch.arange(seq_len, device=x_part.device, dtype=torch.long).view(1, seq_len, 1)
+                token_ids_full = token_ids_full.expand(bsz, seq_len, k_slots)
+
+                real_mask = ~null_part
+                if not bool(real_mask.any()):
+                    return
+
+                sample_ids = sample_ids_full[real_mask]
+                token_ids = token_ids_full[real_mask]
+                expert_ids = idx_part[real_mask].to(torch.long)
+                assign_w = w_part[real_mask].unsqueeze(1)
+
+                x_tok = x_part[sample_ids, token_ids]
+                dy_tok = dy_part[sample_ids, token_ids]
+
+                # Group assignments by expert.
+                order_e = expert_ids.argsort(stable=True)
+                expert_ids = expert_ids[order_e]
+                sample_ids = sample_ids[order_e]
+                x_tok = x_tok[order_e]
+                dy_tok = dy_tok[order_e]
+                assign_w = assign_w[order_e]
+
+                uniq_e, counts_e = torch.unique_consecutive(expert_ids, return_counts=True)
+                starts_e = torch.cumsum(counts_e, dim=0) - counts_e
+
+                for e_val, s_e, c_e in zip(uniq_e.tolist(), starts_e.tolist(), counts_e.tolist()):
+                    e = int(e_val)
+                    ee = int(s_e)
+                    ff = int(s_e + c_e)
+
+                    sids_e = sample_ids[ee:ff]
+                    x_e = x_tok[ee:ff]
+                    dy_e = dy_tok[ee:ff]
+                    w_e = assign_w[ee:ff]
+
+                    wg_f = _fetch_weight(wg_weight_cache, cap.w_gate, e)
+                    wu_f = _fetch_weight(wu_weight_cache, cap.w_up, e)
+                    wd_f = _fetch_weight(wd_weight_cache, cap.w_down, e)
+
+                    dz_e = dy_e * w_e
+                    dz_e, bad_dz = self._sanitize_for_scoring(dz_e)
+                    total_bad_grad += float(bad_dz)
+
+                    g1_e = x_e.matmul(wg_f)
+                    g2_e = x_e.matmul(wu_f)
+                    silu_g1_e = torch.nn.functional.silu(g1_e)
+                    h_e = silu_g1_e * g2_e
+
+                    dh_e = dz_e.matmul(wd_f.transpose(0, 1))
+                    dg1_e = dh_e * g2_e * self._silu_prime(g1_e)
+                    dg2_e = dh_e * silu_g1_e
+
+                    p_wg = _fetch_precond(wg_cache, cap.w_gate, e)
+                    p_wu = _fetch_precond(wu_cache, cap.w_up, e)
+                    p_wd = _fetch_precond(wd_cache, cap.w_down, e)
+
+                    # Group by sample id inside expert.
+                    order_s = sids_e.argsort(stable=True)
+                    sids_s = sids_e[order_s]
+                    x_s = x_e[order_s]
+                    h_s = h_e[order_s]
+                    dz_s = dz_e[order_s]
+                    dg1_s = dg1_e[order_s]
+                    dg2_s = dg2_e[order_s]
+
+                    uniq_s, counts_s = torch.unique_consecutive(sids_s, return_counts=True)
+                    starts_s = torch.cumsum(counts_s, dim=0) - counts_s
+
+                    for sid, ss, cc in zip(uniq_s.tolist(), starts_s.tolist(), counts_s.tolist()):
+                        a = int(ss)
+                        b = int(ss + cc)
+                        sample_id = int(sid)
+                        x_sel = x_s[a:b]
+                        h_sel = h_s[a:b]
+                        dz_sel = dz_s[a:b]
+                        dg1_sel = dg1_s[a:b]
+                        dg2_sel = dg2_s[a:b]
+
+                        gate_sk, up_sk = self.projector.project_outer_sum_pair_sample(
+                            left=x_sel,
+                            right_a=dg1_sel,
+                            right_b=dg2_sel,
+                            preconditioner_a=p_wg,
+                            preconditioner_b=p_wu,
+                            row_dim=wg_f.shape[0],
+                            col_dim=wg_f.shape[1],
+                            out_dtype=out_dtype,
+                            sketch_key_a=f"{layer_name}.moe.W_gate.expert{e}",
+                            sketch_key_b=f"{layer_name}.moe.W_up.expert{e}",
+                        )
+                        down_sk = self.projector.project_outer_sum_sample(
+                            left=h_sel,
+                            right=dz_sel,
+                            preconditioner=p_wd,
+                            row_dim=wd_f.shape[0],
+                            col_dim=wd_f.shape[1],
+                            out_dtype=out_dtype,
+                            sketch_key=f"{layer_name}.moe.W_down.expert{e}",
+                        )
+
+                        out_gate[sample_id] += gate_sk
+                        out_up[sample_id] += up_sk
+                        out_down[sample_id] += down_sk
+
+            _accumulate_partition(x_cand, dy_cand, idx_cand, w_cand, null_cand, feat_gate_c, feat_up_c, feat_down_c)
+            _accumulate_partition(x_proxy, dy_proxy, idx_proxy, w_proxy, null_proxy, feat_gate_p, feat_up_p, feat_down_p)
+
+            candidate_features[f"{layer_name}.moe.W_gate"] = feat_gate_c
+            candidate_features[f"{layer_name}.moe.W_up"] = feat_up_c
+            candidate_features[f"{layer_name}.moe.W_down"] = feat_down_c
+
+            proxy_features[f"{layer_name}.moe.W_gate"] = feat_gate_p.mean(dim=0)
+            proxy_features[f"{layer_name}.moe.W_up"] = feat_up_p.mean(dim=0)
+            proxy_features[f"{layer_name}.moe.W_down"] = feat_down_p.mean(dim=0)
+
+            # Explicitly release per-layer local references.
+            del cap, x_all, dy_all, topk_idx, topk_weight, is_null
+
+        stats = {
+            "nonfinite_moe_activations": total_bad_act,
+            "nonfinite_moe_grad_outputs": total_bad_grad,
+            "nonfinite_moe_preconditioner": total_bad_precond,
+        }
+        return candidate_features, proxy_features, stats
+
+    def build_sketch_features(
+        self,
+        captures: Dict[str, LayerCapture],
+        candidate_count: int,
+        proxy_count: int,
+        preconditioner: AdamWPreconditionerView,
+        moe_captures: Optional[Dict[str, MoERoutedCapture]] = None,
+        out_dtype: torch.dtype = torch.float32,
+    ) -> Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
+        """
+        Returns:
+            candidate_features: layer -> [N_local, m]
+            proxy_features: layer -> [m]
+        """
+        candidate_features: Dict[str, torch.Tensor] = {}
+        proxy_features: Dict[str, torch.Tensor] = {}
+
+        total_bad_act = 0
+        total_bad_grad = 0
+        total_bad_precond = 0
+
+        for layer_name, cap in list(captures.items()):
+            a_all_raw = self._ensure_btd(cap.activations)
+            g_all_raw = self._ensure_btd(cap.grad_outputs)
+            a_all, bad_act = self._sanitize_for_scoring(a_all_raw)
+            g_all, bad_grad = self._sanitize_for_scoring(g_all_raw)
+            total_bad_act += bad_act
+            total_bad_grad += bad_grad
+
+            if a_all.shape[0] < candidate_count + proxy_count:
+                raise RuntimeError(
+                    f"Layer {layer_name} captured batch too small: {a_all.shape[0]} < {candidate_count + proxy_count}"
+                )
+
+            a_cand = a_all[:candidate_count]
+            g_cand = g_all[:candidate_count]
+            a_proxy = a_all[candidate_count:candidate_count + proxy_count]
+            g_proxy = g_all[candidate_count:candidate_count + proxy_count]
+
+            out_dim, in_dim = cap.weight.shape
+            p_t_raw = preconditioner.get(cap.weight)
+            p_t, bad_precond = self._sanitize_for_scoring(p_t_raw)
+            total_bad_precond += bad_precond
+
+            cand = self.projector.project_linear_batch(
+                activations=a_cand,
+                grad_outputs=g_cand,
+                preconditioner=p_t,
+                out_dim=out_dim,
+                in_dim=in_dim,
+                out_dtype=out_dtype,
+                sketch_key=f"{layer_name}.weight",
+            )
+
+            proxy = self.projector.project_linear_batch(
+                activations=a_proxy,
+                grad_outputs=g_proxy,
+                preconditioner=None,
+                out_dim=out_dim,
+                in_dim=in_dim,
+                out_dtype=out_dtype,
+                sketch_key=f"{layer_name}.weight",
+            ).mean(dim=0)
+
+            candidate_features[layer_name] = cand
+            proxy_features[layer_name] = proxy
+
+            # Explicitly drop raw capture buffers once sketched.
+            del cap, a_all_raw, g_all_raw, a_all, g_all, a_cand, g_cand, a_proxy, g_proxy, cand, proxy
+
+        if moe_captures:
+            moe_cand, moe_proxy, moe_stats = self._build_moe_features(
+                moe_captures=moe_captures,
+                candidate_count=candidate_count,
+                proxy_count=proxy_count,
+                preconditioner=preconditioner,
+                out_dtype=out_dtype,
+            )
+            candidate_features.update(moe_cand)
+            proxy_features.update(moe_proxy)
+            total_bad_act += int(moe_stats.get("nonfinite_moe_activations", 0.0))
+            total_bad_grad += int(moe_stats.get("nonfinite_moe_grad_outputs", 0.0))
+            total_bad_precond += int(moe_stats.get("nonfinite_moe_preconditioner", 0.0))
+
+        if not candidate_features:
+            raise RuntimeError("No candidate features were built for OPUS")
+        self._last_feature_stats = {
+            "nonfinite_activations": float(total_bad_act),
+            "nonfinite_grad_outputs": float(total_bad_grad),
+            "nonfinite_preconditioner": float(total_bad_precond),
+        }
+        return candidate_features, proxy_features
+
+    @staticmethod
+    def _fallback_local_random(n_local: int, k_local: int, device: torch.device, rng: torch.Generator) -> torch.Tensor:
+        perm = torch.randperm(n_local, generator=rng)[:k_local]
+        return perm.to(device=device, dtype=torch.long)
+
+    def _rand_uniform_like(self, ref: torch.Tensor) -> torch.Tensor:
+        flat = torch.rand(ref.numel(), generator=self._rng, dtype=torch.float32)
+        return flat.view_as(ref).to(device=ref.device, dtype=ref.dtype)
+
+    def _local_gumbel_argmax(self, logits: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        u = self._rand_uniform_like(logits).clamp_(min=1e-6, max=1.0 - 1e-6)
+        g = -torch.log(-torch.log(u))
+        perturbed = logits + g
+        best_val, best_idx = torch.max(perturbed, dim=0)
+        return best_val, best_idx
+
+    @staticmethod
+    def _global_pick_from_rank_bests(
+        local_best_value: torch.Tensor,
+        local_best_index: torch.Tensor,
+        local_best_score: torch.Tensor,
+        n_local: int,
+        device: torch.device,
+    ) -> Tuple[int, float]:
+        gathered_vals = all_gather_1d(local_best_value.view(1))
+        gathered_idx = all_gather_1d(local_best_index.view(1).to(torch.long))
+        gathered_score = all_gather_1d(local_best_score.view(1))
+
+        if get_rank() == 0:
+            owner = int(torch.argmax(gathered_vals).item())
+            best_val = float(gathered_vals[owner].item())
+            if not math.isfinite(best_val) or best_val <= torch.finfo(gathered_vals.dtype).min * 0.5:
+                chosen = -1
+                chosen_score = 0.0
+            else:
+                local_idx = int(gathered_idx[owner].item())
+                chosen = owner * n_local + local_idx
+                chosen_score = float(gathered_score[owner].item())
+        else:
+            chosen = -1
+            chosen_score = 0.0
+
+        chosen_t = torch.tensor([chosen], device=device, dtype=torch.long)
+        chosen_score_t = torch.tensor([chosen_score], device=device, dtype=torch.float32)
+        broadcast_tensor(chosen_t, src=0)
+        broadcast_tensor(chosen_score_t, src=0)
+        return int(chosen_t.item()), float(chosen_score_t.item())
+
+    def _chosen_probability(
+        self,
+        logits: torch.Tensor,
+        chosen_score: float,
+        temperature: float,
+        logits_are_global: bool = False,
+    ) -> float:
+        # exact categorical p(chosen) from distributed logits via scalar reductions
+        temp = max(float(temperature), 1e-6)
+        if logits_are_global:
+            global_max = logits.max().view(1).to(torch.float32)
+            shifted = logits.to(torch.float32) - global_max
+            denom = float(torch.exp(shifted).sum().item())
+        else:
+            local_max = logits.max().view(1).to(torch.float32)
+            global_max = all_reduce_max(local_max.clone())
+            shifted = logits.to(torch.float32) - global_max
+            exp_sum_local = torch.exp(shifted).sum().view(1)
+            exp_sum_global = all_reduce_sum(exp_sum_local.clone())
+            denom = float(exp_sum_global.item())
+        if not math.isfinite(denom) or denom <= 0.0:
+            return 0.0
+        num = math.exp((float(chosen_score) / temp) - float(global_max.item()))
+        p = num / denom
+        if not math.isfinite(p) or p <= 0.0:
+            return 0.0
+        return float(p)
+
+    def select(
+        self,
+        candidate_features: Dict[str, torch.Tensor],
+        proxy_features: Dict[str, torch.Tensor],
+        learning_rate: float,
+    ) -> SelectionResult:
+        """
+        Global Boltzmann selection with redundancy updates.
+        """
+        t_start = time.perf_counter()
+        rank = get_rank()
+        world = get_world_size()
+
+        if not math.isfinite(float(learning_rate)):
+            raise ValueError(f"learning_rate must be finite, got {learning_rate}")
+
+        layer_names = sorted(candidate_features.keys())
+        cand_raw = torch.stack([candidate_features[n] for n in layer_names], dim=1)  # [N_local, L, m]
+        proxy_raw = torch.stack([proxy_features[n] for n in layer_names], dim=0)  # [L, m]
+        cand, bad_cand = self._sanitize_for_scoring(cand_raw)
+        proxy, bad_proxy = self._sanitize_for_scoring(proxy_raw)
+
+        n_local = cand.size(0)
+        device = cand.device
+
+        shared_candidates = bool(self.config.zero2_exact_global_scoring) and world > 1
+        if shared_candidates:
+            k_global = max(1, int(round(self.config.selection_ratio * n_local)))
+        else:
+            k_global = max(1, int(round(self.config.selection_ratio * (n_local * world))))
+        k_local_fallback = max(1, int(round(self.config.selection_ratio * n_local)))
+
+        history = torch.zeros_like(proxy)
+        selected_local = torch.zeros(n_local, dtype=torch.bool, device=device)
+        selected_global_indices: List[int] = []
+
+        alignment_acc = 0.0
+        redundancy_acc = 0.0
+        entropy_acc = 0.0
+        nonfinite_local_scores = 0.0
+
+        used_fallback = False
+        fallback_no_finite = 0.0
+        try:
+            for _ in range(k_global):
+                if (time.perf_counter() - t_start) > self.config.max_selector_time_s:
+                    raise TimeoutError("selector timeout budget exceeded")
+
+                alignment = torch.einsum("nlm,lm->n", cand, proxy)
+                redundancy = torch.einsum("nlm,lm->n", cand, history)
+                local_scores = (learning_rate * alignment) - (learning_rate * learning_rate * redundancy)
+                local_scores = local_scores.to(torch.float32)
+                if self._track_nonfinite:
+                    nonfinite_local_scores += float((~torch.isfinite(local_scores)).sum().item())
+                local_scores = torch.nan_to_num(
+                    local_scores,
+                    nan=torch.finfo(torch.float32).min,
+                    posinf=torch.finfo(torch.float32).min,
+                    neginf=torch.finfo(torch.float32).min,
+                )
+                local_scores[selected_local] = -torch.inf
+
+                if shared_candidates:
+                    # Each rank contributes shard-local utility for the same candidates.
+                    global_scores = all_reduce_sum(local_scores.clone())
+                    temp = max(self.config.temperature, 1e-6)
+                    global_logits = global_scores / temp
+                    if rank == 0:
+                        best_val, best_idx = self._local_gumbel_argmax(global_logits)
+                        chosen = int(best_idx.item())
+                        chosen_score = float(global_scores[best_idx].item())
+                        if (not math.isfinite(float(best_val.item()))) or (chosen_score <= torch.finfo(torch.float32).min * 0.5):
+                            chosen = -1
+                            chosen_score = 0.0
+                    else:
+                        chosen = -1
+                        chosen_score = 0.0
+                    chosen_t = torch.tensor([chosen], device=device, dtype=torch.long)
+                    chosen_score_t = torch.tensor([chosen_score], device=device, dtype=torch.float32)
+                    broadcast_tensor(chosen_t, src=0)
+                    broadcast_tensor(chosen_score_t, src=0)
+                    chosen = int(chosen_t.item())
+                    chosen_score = float(chosen_score_t.item())
+                    local_logits = global_logits
+                else:
+                    temp = max(self.config.temperature, 1e-6)
+                    local_logits = local_scores / temp
+                    local_best_val, local_best_idx = self._local_gumbel_argmax(local_logits)
+                    local_best_score = local_scores[local_best_idx]
+                    chosen, chosen_score = self._global_pick_from_rank_bests(
+                        local_best_value=local_best_val.to(torch.float32),
+                        local_best_index=local_best_idx.to(torch.long),
+                        local_best_score=local_best_score.to(torch.float32),
+                        n_local=n_local,
+                        device=device,
+                    )
+                if chosen < 0:
+                    fallback_no_finite = 1.0
+                    break
+
+                selected_global_indices.append(chosen)
+                if shared_candidates:
+                    local_idx = chosen
+                    selected_local[local_idx] = True
+                    selected_feat = cand[local_idx].clone()
+                else:
+                    owner = chosen // n_local
+                    local_idx = chosen % n_local
+                    if rank == owner:
+                        selected_local[local_idx] = True
+                        selected_feat = cand[local_idx].clone()
+                    else:
+                        selected_feat = torch.zeros_like(history)
+
+                p = self._chosen_probability(
+                    local_logits,
+                    chosen_score,
+                    self.config.temperature,
+                    logits_are_global=shared_candidates,
+                )
+                if p > 0.0:
+                    entropy_acc += float(-p * math.log(p))
+                alignment_acc += float(chosen_score)
+                work = all_reduce_sum_async(selected_feat)
+                if work is not None:
+                    work.wait()
+                else:
+                    all_reduce_sum(selected_feat)
+                history = history + selected_feat
+                redundancy_acc += float(torch.norm(selected_feat).item())
+
+        except Exception:
+            if not self.config.fallback_random_on_error:
+                raise
+            used_fallback = True
+            if shared_candidates:
+                if rank == 0:
+                    local_idxs = self._fallback_local_random(n_local, k_local_fallback, device, self._rng)
+                else:
+                    local_idxs = torch.empty(k_local_fallback, device=device, dtype=torch.long)
+                broadcast_tensor(local_idxs, src=0)
+                global_idxs = local_idxs.clone()
+            else:
+                local_idxs = self._fallback_local_random(n_local, k_local_fallback, device, self._rng)
+                global_idxs = local_idxs + (rank * n_local)
+            return SelectionResult(
+                selected_local_indices=local_idxs,
+                selected_global_indices=global_idxs,
+                used_fallback=True,
+                metrics={
+                    "alignment": 0.0,
+                    "redundancy": 0.0,
+                    "entropy": 0.0,
+                    "nonfinite_feature_values": float(
+                        bad_cand + bad_proxy + self._last_feature_stats.get("nonfinite_activations", 0.0)
+                        + self._last_feature_stats.get("nonfinite_grad_outputs", 0.0)
+                        + self._last_feature_stats.get("nonfinite_preconditioner", 0.0)
+                    ),
+                    "nonfinite_local_score_values": nonfinite_local_scores,
+                    "fallback_no_finite_scores": fallback_no_finite,
+                    "selector_time_s": float(time.perf_counter() - t_start),
+                },
+            )
+
+        local_indices = torch.nonzero(selected_local, as_tuple=False).flatten()
+        if local_indices.numel() == 0:
+            # Hard floor to avoid empty update on any rank.
+            local_indices = self._fallback_local_random(n_local, k_local_fallback, device, self._rng)
+            used_fallback = True
+            fallback_no_finite = 1.0
+
+        if selected_global_indices:
+            global_idx_tensor = torch.tensor(selected_global_indices, device=device, dtype=torch.long)
+        else:
+            if shared_candidates:
+                global_idx_tensor = local_indices.clone()
+            else:
+                global_idx_tensor = local_indices + (rank * n_local)
+
+        return SelectionResult(
+            selected_local_indices=local_indices,
+            selected_global_indices=global_idx_tensor,
+            used_fallback=used_fallback,
+            metrics={
+                "alignment": alignment_acc,
+                "redundancy": redundancy_acc,
+                "entropy": entropy_acc,
+                "nonfinite_feature_values": float(
+                    bad_cand + bad_proxy + self._last_feature_stats.get("nonfinite_activations", 0.0)
+                    + self._last_feature_stats.get("nonfinite_grad_outputs", 0.0)
+                    + self._last_feature_stats.get("nonfinite_preconditioner", 0.0)
+                ),
+                "nonfinite_local_score_values": nonfinite_local_scores,
+                "fallback_no_finite_scores": fallback_no_finite,
+                "selector_time_s": float(time.perf_counter() - t_start),
+            },
+        )

--- a/llm/src/llm/train.py
+++ b/llm/src/llm/train.py
@@ -140,6 +140,7 @@ def train_epoch(
     profiler: "StepProfiler | None" = None,
     profile_steps: "set | None" = None,
     profile_output_dir: "str | None" = None,
+    opus_selector=None,
 ):
     """
     Train the model for one epoch.
@@ -224,6 +225,27 @@ def train_epoch(
             labels = batch["labels"].to(model_engine.device, non_blocking=True)
             if torch.cuda.is_available():
                 torch.cuda.synchronize()
+
+        # ── OPUS Data Selection ────────────────────────────────────────────────
+        opus_metrics = None
+        if opus_selector is not None:
+            _opus_ctx = (
+                profiler.phase("opus_select") if profiler is not None else _null_ctx()
+            )
+            with _opus_ctx:
+                selected_batch, opus_metrics = opus_selector.select_batch(
+                    batch, model_engine.device
+                )
+                input_ids = selected_batch["input_ids"].to(
+                    model_engine.device, non_blocking=True
+                )
+                attention_mask = selected_batch["attention_mask"].to(
+                    model_engine.device, non_blocking=True
+                )
+                labels = selected_batch["labels"].to(
+                    model_engine.device, non_blocking=True
+                )
+                model_engine.zero_grad(set_to_none=True)
 
         # Memory profiling on first step
         mem_before = 0
@@ -399,6 +421,10 @@ def train_epoch(
         with profiler.phase("optim_step") if profiler is not None else _null_ctx():
             model_engine.step()
 
+        # OPUS: refresh preconditioner with updated optimizer state
+        if opus_selector is not None:
+            opus_selector.refresh_preconditioner()
+
         if i == 0:
             mem_after_step = torch.cuda.memory_allocated(model_engine.device) / 1e9
             print_rank_0(f"[MEMORY] After backward & step: {mem_after_step:.2f}GB")
@@ -557,53 +583,53 @@ def train_epoch(
                         )
                 print_rank_0(msg)
                 if metrics_jsonl_path is not None:
-                    _append_jsonl(
-                        metrics_jsonl_path,
-                        {
-                            "phase": "train",
-                            "epoch": epoch,
-                            "step": i,
-                            "global_step": global_step,
-                            "loss": float(loss.item()),
-                            "loss_ntp": (
-                                None
-                                if loss_ntp_value is None
-                                else float(loss_ntp_value)
-                            ),
-                            "loss2": (
-                                None
-                                if loss_mtp_value is None
-                                else float(loss_mtp_value)
-                            ),
-                            "r_loss": (
-                                None
-                                if loss_aux_value is None
-                                else float(loss_aux_value)
-                            ),
-                            "lr": (
-                                None if learning_rate is None else float(learning_rate)
-                            ),
-                            "dt_ms": float(step_dt_ms),
-                            "tokens_per_sec": float(tokens_per_sec),
-                            "tokens": int(tokens),
-                            "gpu_util": None if gpu_util is None else float(gpu_util),
-                            "gpu_mem_used_gb": (
-                                None if gpu_mem_used is None else float(gpu_mem_used)
-                            ),
-                            "cpu_util": None if cpu_util is None else float(cpu_util),
-                            "cpu_mem_used_gb": (
-                                None if cpu_mem_used is None else float(cpu_mem_used)
-                            ),
-                            "gsa_leak_fraction": (
-                                None if gsa_leak_frac is None else float(gsa_leak_frac)
-                            ),
-                            "gsa_leak_attempt_fraction": (
-                                None
-                                if gsa_leak_attempt_frac is None
-                                else float(gsa_leak_attempt_frac)
-                            ),
-                        },
-                    )
+                    metrics = {
+                        "phase": "train",
+                        "epoch": epoch,
+                        "step": i,
+                        "global_step": global_step,
+                        "loss": float(loss.item()),
+                        "loss_ntp": (
+                            None
+                            if loss_ntp_value is None
+                            else float(loss_ntp_value)
+                        ),
+                        "loss2": (
+                            None
+                            if loss_mtp_value is None
+                            else float(loss_mtp_value)
+                        ),
+                        "r_loss": (
+                            None
+                            if loss_aux_value is None
+                            else float(loss_aux_value)
+                        ),
+                        "lr": (
+                            None if learning_rate is None else float(learning_rate)
+                        ),
+                        "dt_ms": float(step_dt_ms),
+                        "tokens_per_sec": float(tokens_per_sec),
+                        "tokens": int(tokens),
+                        "gpu_util": None if gpu_util is None else float(gpu_util),
+                        "gpu_mem_used_gb": (
+                            None if gpu_mem_used is None else float(gpu_mem_used)
+                        ),
+                        "cpu_util": None if cpu_util is None else float(cpu_util),
+                        "cpu_mem_used_gb": (
+                            None if cpu_mem_used is None else float(cpu_mem_used)
+                        ),
+                        "gsa_leak_fraction": (
+                            None if gsa_leak_frac is None else float(gsa_leak_frac)
+                        ),
+                        "gsa_leak_attempt_fraction": (
+                            None
+                            if gsa_leak_attempt_frac is None
+                            else float(gsa_leak_attempt_frac)
+                        ),
+                    }
+                    if opus_metrics is not None:
+                        metrics.update(opus_metrics)
+                    _append_jsonl(metrics_jsonl_path, metrics)
 
                 # Print full GPU table (all devices) when enabled and available
                 if enable_system_metrics and is_main_process():

--- a/llm/src/llm/train.py
+++ b/llm/src/llm/train.py
@@ -213,6 +213,18 @@ def train_epoch(
         # Measure step wall-clock time
         step_start_time = time.time()
 
+        # ── OPUS Data Selection (before device transfer to avoid wasted copy) ──
+        opus_metrics = None
+        if opus_selector is not None:
+            _opus_ctx = (
+                profiler.phase("opus_select") if profiler is not None else _null_ctx()
+            )
+            with _opus_ctx:
+                batch, opus_metrics = opus_selector.select_batch(
+                    batch, model_engine.device
+                )
+                model_engine.zero_grad(set_to_none=True)
+
         # ── Profiler: dataloader + device transfer ───────────────────────────
         _profiler_ctx = (
             profiler.phase("dataloader") if profiler is not None else _null_ctx()
@@ -225,27 +237,6 @@ def train_epoch(
             labels = batch["labels"].to(model_engine.device, non_blocking=True)
             if torch.cuda.is_available():
                 torch.cuda.synchronize()
-
-        # ── OPUS Data Selection ────────────────────────────────────────────────
-        opus_metrics = None
-        if opus_selector is not None:
-            _opus_ctx = (
-                profiler.phase("opus_select") if profiler is not None else _null_ctx()
-            )
-            with _opus_ctx:
-                selected_batch, opus_metrics = opus_selector.select_batch(
-                    batch, model_engine.device
-                )
-                input_ids = selected_batch["input_ids"].to(
-                    model_engine.device, non_blocking=True
-                )
-                attention_mask = selected_batch["attention_mask"].to(
-                    model_engine.device, non_blocking=True
-                )
-                labels = selected_batch["labels"].to(
-                    model_engine.device, non_blocking=True
-                )
-                model_engine.zero_grad(set_to_none=True)
 
         # Memory profiling on first step
         mem_before = 0

--- a/llm/tests/opus/test_config.py
+++ b/llm/tests/opus/test_config.py
@@ -1,0 +1,50 @@
+"""Tests for OpusConfig dataclass."""
+
+from llm.opus.config import OpusConfig
+
+
+def test_opus_config_defaults():
+    """Verify all default values are set correctly."""
+    cfg = OpusConfig()
+    assert cfg.enabled is False
+    assert cfg.selection_mode == "opus"
+    assert cfg.candidate_multiplier == 2
+    assert cfg.selection_ratio == 0.5
+    assert cfg.score_seq_len == 512
+    assert cfg.proxy_batch_size == 8
+    assert cfg.sketch_dim == 8192
+    assert cfg.temperature == 0.9
+    assert cfg.sketch_seed == 42
+    assert cfg.fallback_random_on_error is True
+    assert cfg.max_selector_time_s == 30.0
+    assert cfg.include_embeddings is False
+    assert cfg.include_lm_head is False
+    assert cfg.track_nonfinite_stats is True
+    assert cfg.zero2_exact_global_scoring is True
+    assert cfg.strict_shard_preconditioner is False
+    assert cfg.log_selection_metrics is True
+
+
+def test_opus_config_from_dict():
+    """Verify from_dict works with a partial dictionary."""
+    cfg = OpusConfig.from_dict({"enabled": True, "selection_mode": "random", "sketch_dim": 4096})
+    assert cfg.enabled is True
+    assert cfg.selection_mode == "random"
+    assert cfg.sketch_dim == 4096
+    # Other fields should retain defaults
+    assert cfg.candidate_multiplier == 2
+    assert cfg.temperature == 0.9
+
+
+def test_opus_config_from_dict_ignores_unknown_keys():
+    """Verify unknown keys in the dictionary are silently ignored."""
+    cfg = OpusConfig.from_dict({
+        "enabled": True,
+        "unknown_key": "should_be_ignored",
+        "another_unknown": 999,
+    })
+    assert cfg.enabled is True
+    # Defaults still hold for unspecified fields
+    assert cfg.selection_mode == "opus"
+    assert not hasattr(cfg, "unknown_key")
+    assert not hasattr(cfg, "another_unknown")

--- a/llm/tests/opus/test_countsketch.py
+++ b/llm/tests/opus/test_countsketch.py
@@ -1,0 +1,33 @@
+"""Tests for CountSketchProjector determinism and correctness."""
+import torch
+from llm.opus.countsketch import CountSketchProjector
+
+
+def test_countsketch_deterministic():
+    proj = CountSketchProjector(sketch_dim=64, seed=42)
+    # project_linear_batch expects activations [B, in_dim], grad_outputs [B, out_dim]
+    activations = torch.randn(10, 128)
+    grad_outputs = torch.randn(10, 64)
+    out1 = proj.project_linear_batch(activations, grad_outputs, preconditioner=None, out_dim=64, in_dim=128)
+    out2 = proj.project_linear_batch(activations, grad_outputs, preconditioner=None, out_dim=64, in_dim=128)
+    assert torch.allclose(out1, out2), "CountSketch must be deterministic"
+
+
+def test_countsketch_output_shape():
+    proj = CountSketchProjector(sketch_dim=256, seed=42)
+    activations = torch.randn(5, 1024)
+    grad_outputs = torch.randn(5, 512)
+    out = proj.project_linear_batch(activations, grad_outputs, preconditioner=None, out_dim=512, in_dim=1024)
+    assert out.shape == (5, 256)
+
+
+def test_countsketch_different_seeds_differ():
+    activations = torch.randn(5, 128)
+    grad_outputs = torch.randn(5, 64)
+    out1 = CountSketchProjector(sketch_dim=64, seed=1).project_linear_batch(
+        activations, grad_outputs, preconditioner=None, out_dim=64, in_dim=128
+    )
+    out2 = CountSketchProjector(sketch_dim=64, seed=2).project_linear_batch(
+        activations, grad_outputs, preconditioner=None, out_dim=64, in_dim=128
+    )
+    assert not torch.allclose(out1, out2)

--- a/llm/tests/opus/test_data_selector.py
+++ b/llm/tests/opus/test_data_selector.py
@@ -1,0 +1,137 @@
+"""Tests for OpusDataSelector composable middleware."""
+import torch
+import torch.nn as nn
+from llm.opus.config import OpusConfig
+from llm.opus.data_selector import OpusDataSelector
+
+
+class TinyModel(nn.Module):
+    """
+    Minimal model that satisfies GhostCollector discovery requirements:
+    - Has nn.Linear modules with "layers." in their path
+    - Has an lm_head nn.Linear
+    - forward accepts input_ids and kwargs (return_hidden, return_memory)
+    - Returns (hidden_states, None, aux_loss)
+    """
+
+    def __init__(self, vocab_size: int = 32, hidden_dim: int = 16):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, hidden_dim)
+        # GhostCollector looks for "layers." in module path with nn.Linear + 2D weight
+        self.layers = nn.ModuleList([
+            nn.ModuleDict({
+                "attn": nn.Linear(hidden_dim, hidden_dim, bias=False),
+                "ff": nn.Linear(hidden_dim, hidden_dim, bias=False),
+            })
+            for _ in range(2)
+        ])
+        self.lm_head = nn.Linear(hidden_dim, vocab_size, bias=False)
+
+    def forward(self, input_ids, **kwargs):
+        h = self.embed(input_ids)
+        for layer in self.layers:
+            h = h + layer["attn"](h)
+            h = h + layer["ff"](h)
+        return h, None, torch.tensor(0.0, device=h.device)
+
+
+def _make_optimizer(model):
+    return torch.optim.AdamW(model.parameters(), lr=1e-3)
+
+
+def _make_candidate_batch(batch_size: int = 8, seq_len: int = 16, vocab_size: int = 32):
+    return {
+        "input_ids": torch.randint(0, vocab_size, (batch_size, seq_len)),
+        "labels": torch.randint(0, vocab_size, (batch_size, seq_len)),
+    }
+
+
+def _make_proxy_loader(n_batches: int = 10, batch_size: int = 4, seq_len: int = 16, vocab_size: int = 32):
+    batches = [
+        {"input_ids": torch.randint(0, vocab_size, (batch_size, seq_len))}
+        for _ in range(n_batches)
+    ]
+    return iter(batches)
+
+
+def test_data_selector_select_batch_reduces_batch():
+    """OPUS scoring mode should return a batch smaller than the input."""
+    torch.manual_seed(42)
+    vocab_size = 32
+    hidden_dim = 16
+    model = TinyModel(vocab_size=vocab_size, hidden_dim=hidden_dim)
+    optimizer = _make_optimizer(model)
+
+    # Do a dummy step so optimizer state is populated
+    dummy = torch.randint(0, vocab_size, (2, 16))
+    h, _, aux = model(dummy)
+    logits = model.lm_head(h)
+    loss = nn.functional.cross_entropy(logits.view(-1, vocab_size), dummy.view(-1))
+    loss.backward()
+    optimizer.step()
+    optimizer.zero_grad()
+
+    cfg = OpusConfig(
+        enabled=True,
+        selection_mode="opus",
+        selection_ratio=0.5,
+        score_seq_len=16,
+        sketch_dim=64,
+        temperature=0.9,
+        fallback_random_on_error=True,
+        include_embeddings=False,
+        include_lm_head=False,
+    )
+
+    proxy_loader = _make_proxy_loader(vocab_size=vocab_size)
+    selector = OpusDataSelector(
+        config=cfg,
+        model=model,
+        optimizer=optimizer,
+        proxy_loader=proxy_loader,
+    )
+
+    candidate_batch = _make_candidate_batch(batch_size=8, vocab_size=vocab_size)
+    device = torch.device("cpu")
+
+    selected_batch, metrics = selector.select_batch(candidate_batch, device)
+
+    # Selection ratio 0.5 of 8 = 4
+    assert selected_batch["input_ids"].shape[0] <= candidate_batch["input_ids"].shape[0]
+    assert selected_batch["input_ids"].shape[0] > 0
+    assert "opus_mode" in metrics
+    assert selected_batch["labels"].shape[0] == selected_batch["input_ids"].shape[0]
+
+
+def test_data_selector_random_mode():
+    """Random mode should bypass OPUS scoring entirely."""
+    torch.manual_seed(42)
+    vocab_size = 32
+    model = TinyModel(vocab_size=vocab_size)
+    optimizer = _make_optimizer(model)
+
+    cfg = OpusConfig(
+        enabled=True,
+        selection_mode="random",
+        selection_ratio=0.5,
+        score_seq_len=16,
+        sketch_dim=64,
+    )
+
+    proxy_loader = _make_proxy_loader(vocab_size=vocab_size)
+    selector = OpusDataSelector(
+        config=cfg,
+        model=model,
+        optimizer=optimizer,
+        proxy_loader=proxy_loader,
+    )
+
+    candidate_batch = _make_candidate_batch(batch_size=8, vocab_size=vocab_size)
+    device = torch.device("cpu")
+
+    selected_batch, metrics = selector.select_batch(candidate_batch, device)
+
+    assert metrics["opus_mode"] == "random"
+    assert selected_batch["input_ids"].shape[0] == 4  # 0.5 * 8
+    assert selected_batch["labels"].shape[0] == 4
+    assert metrics["opus_selected_n"] == 4

--- a/llm/tests/opus/test_ghost.py
+++ b/llm/tests/opus/test_ghost.py
@@ -1,0 +1,38 @@
+"""Tests for GhostCollector hook attachment and capture."""
+import torch
+import torch.nn as nn
+from llm.opus.ghost import GhostCollector
+
+
+def _make_tiny_model():
+    """Build a model with 'layers.' in the module path so _should_track finds it."""
+    model = nn.Module()
+    block = nn.Sequential(nn.Linear(16, 16), nn.ReLU(), nn.Linear(16, 16))
+    model.add_module("layers", nn.ModuleList([block]))
+    return model
+
+
+def test_ghost_collector_captures_activations():
+    model = _make_tiny_model()
+    x = torch.randn(2, 16)
+    with GhostCollector(model, include_embeddings=False, include_lm_head=False) as gc:
+        out = model.layers[0](x)
+        loss = out.sum()
+        loss.backward()
+        captures = gc.captures()
+    assert len(captures) > 0, "GhostCollector should capture at least one layer"
+    for name, cap in captures.items():
+        assert cap.activations is not None
+        assert cap.grad_outputs is not None
+
+
+def test_ghost_collector_cleanup():
+    model = _make_tiny_model()
+    with GhostCollector(model) as gc:
+        # Run a forward+backward so register() succeeds
+        out = model.layers[0](torch.randn(2, 16))
+        out.sum().backward()
+    # After exiting context, all hooks should be removed
+    for mod in model.modules():
+        assert len(mod._forward_hooks) == 0
+        assert len(mod._backward_hooks) == 0

--- a/llm/tests/opus/test_preconditioner.py
+++ b/llm/tests/opus/test_preconditioner.py
@@ -1,0 +1,48 @@
+"""Tests for AdamWPreconditionerView."""
+import torch
+from llm.opus.preconditioner import AdamWPreconditionerView
+
+
+def test_preconditioner_scalar_fallback():
+    """Before first optimizer step, falls back to scalar C_t."""
+    model = torch.nn.Linear(8, 4)
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-3, betas=(0.9, 0.95), eps=1e-8)
+    precond = AdamWPreconditionerView(opt)
+    p = next(model.parameters())
+    result = precond.get(p)
+    assert result is not None
+
+
+def test_preconditioner_after_step():
+    """After one optimizer step, returns proper preconditioner vector."""
+    model = torch.nn.Linear(8, 4)
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-3, betas=(0.9, 0.95), eps=1e-8)
+    loss = model(torch.randn(2, 8)).sum()
+    loss.backward()
+    opt.step()
+    opt.zero_grad()
+    precond = AdamWPreconditionerView(opt)
+    p = next(model.parameters())
+    result = precond.get(p)
+    assert result.shape == p.shape
+    assert torch.isfinite(result).all()
+
+
+def test_preconditioner_refresh():
+    """Refresh rebuilds cache from updated optimizer state."""
+    model = torch.nn.Linear(8, 4)
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    loss = model(torch.randn(2, 8)).sum()
+    loss.backward()
+    opt.step()
+    opt.zero_grad()
+    precond = AdamWPreconditionerView(opt)
+    p = next(model.parameters())
+    v1 = precond.get(p).clone()
+    loss = model(torch.randn(2, 8)).sum()
+    loss.backward()
+    opt.step()
+    opt.zero_grad()
+    precond.refresh()
+    v2 = precond.get(p)
+    assert not torch.allclose(v1, v2), "Preconditioner should change after refresh"

--- a/llm/tests/opus/test_public_api.py
+++ b/llm/tests/opus/test_public_api.py
@@ -1,0 +1,21 @@
+"""Test that the public API is importable."""
+
+
+def test_opus_public_imports():
+    from llm.opus import (
+        OpusConfig,
+        OpusDataSelector,
+        OpusSelector,
+        SelectionResult,
+        GhostCollector,
+        CountSketchProjector,
+        AdamWPreconditionerView,
+    )
+
+    assert OpusConfig is not None
+    assert OpusDataSelector is not None
+    assert OpusSelector is not None
+    assert SelectionResult is not None
+    assert GhostCollector is not None
+    assert CountSketchProjector is not None
+    assert AdamWPreconditionerView is not None

--- a/llm/tests/opus/test_selector.py
+++ b/llm/tests/opus/test_selector.py
@@ -1,0 +1,22 @@
+"""Tests for OpusSelector."""
+import torch
+from llm.opus.config import OpusConfig
+from llm.opus.selector import OpusSelector, SelectionResult
+
+
+def test_selector_init():
+    cfg = OpusConfig(sketch_dim=64, temperature=0.9, sketch_seed=42)
+    selector = OpusSelector(cfg)
+    assert selector is not None
+
+
+def test_selection_result_dataclass():
+    result = SelectionResult(
+        selected_local_indices=torch.tensor([0, 2]),
+        selected_global_indices=torch.tensor([0, 2]),
+        used_fallback=False,
+        metrics={"mean_score": 0.5},
+    )
+    assert result.selected_local_indices.shape == (2,)
+    assert result.used_fallback is False
+    assert result.metrics["mean_score"] == 0.5


### PR DESCRIPTION
## Summary

- Integrates OPUS (arXiv:2602.05400) dynamic per-step data selection into the LLM training pipeline
- Each training step scores N candidate samples and trains on the best rho*N, guided by AdamW preconditioner geometry
- Implemented as a composable middleware (`OpusDataSelector`) with minimal changes to existing `train.py` and `main.py`
- Fully toggleable — disabled by default (`opus.enabled: false`), zero overhead when off

## Architecture

```
DataLoader (2x batch) → OpusDataSelector.select_batch() → selected batch (1x) → train_epoch (unchanged)
```

- Scoring pass runs on unwrapped `model_engine.module` (bypasses DeepSpeed ZeRO gradient sync)
- Uses standard CE (not FusedLinearCE) for scoring to support ghost hook gradient capture
- Preconditioner uses DeepSpeed's official `safe_get_full_optimizer_state()` API
- `RandomInDistributionProxyProvider` auto-resets on epoch boundaries

## New files (llm/src/llm/opus/)

| File | Description |
|------|-------------|
| `config.py` | `OpusConfig` dataclass with `from_dict()` factory |
| `ghost.py` | `GhostCollector` — forward/backward hooks for activation+gradient capture |
| `countsketch.py` | `CountSketchProjector` — dimensionality reduction for gradient sketches |
| `preconditioner.py` | `AdamWPreconditionerView` — reads optimizer state for scoring geometry |
| `selector.py` | `OpusSelector` — scoring + Boltzmann sampling selection |
| `proxy.py` | Proxy data providers (random in-distribution, benchmark) |
| `data_selector.py` | `OpusDataSelector` — composable middleware encapsulating the full pipeline |
| `distributed.py` | Thin wrappers around `torch.distributed` |

## Modified files

- `llm/main.py` — Parse `opus:` config, create candidate+proxy dataloaders, init `OpusDataSelector`
- `llm/src/llm/train.py` — Add `opus_selector` param, call `select_batch()` before forward, refresh preconditioner after step
- `llm/configs/config.yaml` — Add `opus:` section (disabled by default)

## Test plan

- [x] 16 unit tests covering config, countsketch, ghost, preconditioner, selector, data_selector, public API
- [x] All existing logger tests pass (no regressions)
- [x] Import smoke test passes
- [ ] GPU smoke test: 10 steps with OPUS enabled on single GPU
- [ ] A/B comparison: 100 steps OPUS vs baseline loss curves

🤖 Generated with [Claude Code](https://claude.com/claude-code)