### PR TITLE
Resume recovery optimizor scheduler

### DIFF
--- a/llm/src/llm/pretrainer.py
+++ b/llm/src/llm/pretrainer.py
@@ -11,7 +11,7 @@ from llm.config import Config
 from llm.kernels import HAS_TRITON, FusedLinearCrossEntropyLoss
 from llm.logger import Metrics
 from llm.profiler import PipelineProfiler
-from llm.utils import is_main_process
+from llm.utils import is_main_process, verify_optimizer_scheduler_restored
 
 
 class PreTrainer:
@@ -420,54 +420,24 @@ class PreTrainer:
 
     def _verify_optimizer_scheduler_restored(self, expected_global_step: int):
         """Verify optimizer momentum/variance and scheduler state after resume."""
-        # Unwrap DeepSpeed optimizer wrapper to access raw Adam state
-        raw_optimizer = getattr(self._optimizer, "optimizer", self._optimizer)
-        opt_state = raw_optimizer.state
-
-        if not opt_state:
-            raise RuntimeError(
-                "Optimizer state is empty after checkpoint restore — "
-                "momentum and variance buffers were not loaded."
-            )
-
-        restored_count = 0
-        total_count = 0
-        for _param_id, state in opt_state.items():
-            total_count += 1
-            has_momentum = "exp_avg" in state and state["exp_avg"].any().item()
-            has_variance = "exp_avg_sq" in state and state["exp_avg_sq"].any().item()
-            if has_momentum and has_variance:
-                restored_count += 1
-
-        # Only enforce non-zero check after early steps where Adam buffers
-        # may legitimately still be zero.
-        if expected_global_step > 2 and restored_count == 0:
-            raise RuntimeError(
-                f"Optimizer has {total_count} param states but none contain "
-                "non-zero momentum/variance — restore likely failed."
-            )
-
-        # Check scheduler state
-        current_lr = None
-        last_epoch = None
-        if self._lr_scheduler is not None:
-            if hasattr(self._lr_scheduler, "get_last_lr"):
-                current_lr = self._lr_scheduler.get_last_lr()[0]
-            elif hasattr(self._lr_scheduler, "get_lr"):
-                current_lr = self._lr_scheduler.get_lr()[0]
-
-            if hasattr(self._lr_scheduler, "state_dict"):
-                sched_state = self._lr_scheduler.state_dict()
-                last_epoch = sched_state.get("last_epoch", None)
+        result = verify_optimizer_scheduler_restored(
+            self._optimizer, self._lr_scheduler, expected_global_step
+        )
 
         if is_main_process():
             print(
-                f"[Resume] Optimizer state verified: {restored_count}/{total_count} "
+                f"[Resume] Optimizer state verified: "
+                f"{result['restored_count']}/{result['total_count']} "
                 f"params have non-zero momentum & variance. "
-                f"Current LR: {current_lr}, scheduler last_epoch: {last_epoch}, "
+                f"Current LR: {result['current_lr']}, "
+                f"scheduler last_epoch: {result['last_epoch']}, "
                 f"global_step: {expected_global_step}"
             )
-            if last_epoch is not None and last_epoch == 0 and expected_global_step > 0:
+            if (
+                result["last_epoch"] is not None
+                and result["last_epoch"] == 0
+                and expected_global_step > 0
+            ):
                 print(
                     "[Resume] WARNING: scheduler last_epoch is 0 despite "
                     f"global_step={expected_global_step} — scheduler state "

--- a/llm/src/llm/pretrainer.py
+++ b/llm/src/llm/pretrainer.py
@@ -175,6 +175,7 @@ class PreTrainer:
             start_epoch = client_state.get("epoch", 0)
             global_step = client_state.get("global_step", 0)
             start_step = client_state.get("step", 0)
+            self._verify_optimizer_scheduler_restored(global_step)
             return start_epoch, start_step, global_step
 
         return 0, 0, 0
@@ -416,6 +417,62 @@ class PreTrainer:
 
     def _generate(self):
         pass
+
+    def _verify_optimizer_scheduler_restored(self, expected_global_step: int):
+        """Verify optimizer momentum/variance and scheduler state after resume."""
+        # Unwrap DeepSpeed optimizer wrapper to access raw Adam state
+        raw_optimizer = getattr(self._optimizer, "optimizer", self._optimizer)
+        opt_state = raw_optimizer.state
+
+        if not opt_state:
+            raise RuntimeError(
+                "Optimizer state is empty after checkpoint restore — "
+                "momentum and variance buffers were not loaded."
+            )
+
+        restored_count = 0
+        total_count = 0
+        for _param_id, state in opt_state.items():
+            total_count += 1
+            has_momentum = "exp_avg" in state and state["exp_avg"].any().item()
+            has_variance = "exp_avg_sq" in state and state["exp_avg_sq"].any().item()
+            if has_momentum and has_variance:
+                restored_count += 1
+
+        # Only enforce non-zero check after early steps where Adam buffers
+        # may legitimately still be zero.
+        if expected_global_step > 2 and restored_count == 0:
+            raise RuntimeError(
+                f"Optimizer has {total_count} param states but none contain "
+                "non-zero momentum/variance — restore likely failed."
+            )
+
+        # Check scheduler state
+        current_lr = None
+        last_epoch = None
+        if self._lr_scheduler is not None:
+            if hasattr(self._lr_scheduler, "get_last_lr"):
+                current_lr = self._lr_scheduler.get_last_lr()[0]
+            elif hasattr(self._lr_scheduler, "get_lr"):
+                current_lr = self._lr_scheduler.get_lr()[0]
+
+            if hasattr(self._lr_scheduler, "state_dict"):
+                sched_state = self._lr_scheduler.state_dict()
+                last_epoch = sched_state.get("last_epoch", None)
+
+        if is_main_process():
+            print(
+                f"[Resume] Optimizer state verified: {restored_count}/{total_count} "
+                f"params have non-zero momentum & variance. "
+                f"Current LR: {current_lr}, scheduler last_epoch: {last_epoch}, "
+                f"global_step: {expected_global_step}"
+            )
+            if last_epoch is not None and last_epoch == 0 and expected_global_step > 0:
+                print(
+                    "[Resume] WARNING: scheduler last_epoch is 0 despite "
+                    f"global_step={expected_global_step} — scheduler state "
+                    "may not have been restored."
+                )
 
     def _validate_kernel_policy(self, require_fused_kernels: bool):
         if require_fused_kernels and not HAS_TRITON:

--- a/llm/src/llm/utils.py
+++ b/llm/src/llm/utils.py
@@ -46,3 +46,71 @@ def print_rank_0(*args, **kwargs):
     """
     if is_main_process():
         print(*args, **kwargs)
+
+
+def verify_optimizer_scheduler_restored(
+    optimizer,
+    lr_scheduler,
+    expected_global_step: int,
+) -> dict:
+    """
+    Verify that optimizer momentum/variance and scheduler state were restored
+    correctly after loading a checkpoint.
+
+    Unwraps DeepSpeed optimizer wrappers automatically.
+
+    Args:
+        optimizer: The optimizer (raw PyTorch or DeepSpeed-wrapped).
+        lr_scheduler: The LR scheduler (may be None).
+        expected_global_step: The global step from the loaded checkpoint.
+
+    Returns:
+        Dict with restored_count, total_count, current_lr, last_epoch.
+
+    Raises:
+        RuntimeError: If optimizer state is empty, or if momentum/variance
+            buffers are all zeros when expected_global_step > 2.
+    """
+    raw_optimizer = getattr(optimizer, "optimizer", optimizer)
+    opt_state = raw_optimizer.state
+
+    if not opt_state:
+        raise RuntimeError(
+            "Optimizer state is empty after checkpoint restore — "
+            "momentum and variance buffers were not loaded."
+        )
+
+    restored_count = 0
+    total_count = 0
+    for _param_id, state in opt_state.items():
+        total_count += 1
+        has_momentum = "exp_avg" in state and state["exp_avg"].any().item()
+        has_variance = "exp_avg_sq" in state and state["exp_avg_sq"].any().item()
+        if has_momentum and has_variance:
+            restored_count += 1
+
+    # At early steps (<=2) Adam buffers may legitimately still be zero
+    if expected_global_step > 2 and restored_count == 0:
+        raise RuntimeError(
+            f"Optimizer has {total_count} param states but none contain "
+            "non-zero momentum/variance — restore likely failed."
+        )
+
+    current_lr = None
+    last_epoch = None
+    if lr_scheduler is not None:
+        if hasattr(lr_scheduler, "get_last_lr"):
+            current_lr = lr_scheduler.get_last_lr()[0]
+        elif hasattr(lr_scheduler, "get_lr"):
+            current_lr = lr_scheduler.get_lr()[0]
+
+        if hasattr(lr_scheduler, "state_dict"):
+            sched_state = lr_scheduler.state_dict()
+            last_epoch = sched_state.get("last_epoch", None)
+
+    return {
+        "restored_count": restored_count,
+        "total_count": total_count,
+        "current_lr": current_lr,
+        "last_epoch": last_epoch,
+    }

--- a/llm/tests/local_checkpoint_restore_test.py
+++ b/llm/tests/local_checkpoint_restore_test.py
@@ -1,0 +1,255 @@
+"""
+Integration test for optimizer & scheduler checkpoint restore.
+
+Trains a small (~28M param) GPT-style model on wikitext-2 using plain PyTorch
+(no DeepSpeed, no Triton, no CUDA required). Saves a checkpoint, loads it into
+a fresh model, and verifies the restore using the actual production
+verify_optimizer_scheduler_restored function from llm.utils.
+
+Usage:
+    cd llm
+    uv run python tests/local_checkpoint_restore_test.py
+
+Works on M1 Mac (MPS), Linux (CPU/CUDA), etc.
+"""
+
+import tempfile
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+from transformers import AutoTokenizer
+
+from llm.utils import verify_optimizer_scheduler_restored
+
+
+@dataclass
+class SmallGPTConfig:
+    vocab_size: int = 32000
+    hidden_size: int = 256
+    num_layers: int = 4
+    num_heads: int = 4
+    intermediate_size: int = 512
+    max_seq_len: int = 128
+    dropout: float = 0.0
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, config: SmallGPTConfig):
+        super().__init__()
+        self.ln1 = nn.LayerNorm(config.hidden_size)
+        self.attn = nn.MultiheadAttention(
+            config.hidden_size, config.num_heads, dropout=config.dropout, batch_first=True
+        )
+        self.ln2 = nn.LayerNorm(config.hidden_size)
+        self.mlp = nn.Sequential(
+            nn.Linear(config.hidden_size, config.intermediate_size),
+            nn.GELU(),
+            nn.Linear(config.intermediate_size, config.hidden_size),
+        )
+
+    def forward(self, x, mask=None):
+        h = self.ln1(x)
+        h, _ = self.attn(h, h, h, attn_mask=mask, need_weights=False)
+        x = x + h
+        x = x + self.mlp(self.ln2(x))
+        return x
+
+
+class SmallGPT(nn.Module):
+    def __init__(self, config: SmallGPTConfig):
+        super().__init__()
+        self.config = config
+        self.token_embed = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.pos_embed = nn.Embedding(config.max_seq_len, config.hidden_size)
+        self.layers = nn.ModuleList([TransformerBlock(config) for _ in range(config.num_layers)])
+        self.norm = nn.LayerNorm(config.hidden_size)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self._init_weights()
+
+    def _init_weights(self):
+        for module in self.modules():
+            if isinstance(module, nn.Linear):
+                nn.init.normal_(module.weight, std=0.02)
+                if module.bias is not None:
+                    nn.init.zeros_(module.bias)
+            elif isinstance(module, nn.Embedding):
+                nn.init.normal_(module.weight, std=0.02)
+
+    def forward(self, input_ids):
+        B, T = input_ids.shape
+        positions = torch.arange(T, device=input_ids.device).unsqueeze(0)
+        x = self.token_embed(input_ids) + self.pos_embed(positions)
+        causal_mask = nn.Transformer.generate_square_subsequent_mask(T, device=input_ids.device)
+        for layer in self.layers:
+            x = layer(x, mask=causal_mask)
+        x = self.norm(x)
+        return self.lm_head(x)
+
+
+def load_wikitext2(tokenizer, max_length=128, batch_size=4):
+    from datasets import load_dataset
+
+    dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
+    dataset = dataset.filter(lambda x: len(x["text"].strip()) > 0)
+
+    def tokenize_fn(examples):
+        tok = tokenizer(
+            examples["text"],
+            truncation=True,
+            padding="max_length",
+            max_length=max_length,
+            return_tensors=None,
+        )
+        tok["labels"] = [ids.copy() for ids in tok["input_ids"]]
+        return tok
+
+    dataset = dataset.map(tokenize_fn, batched=True, remove_columns=["text"])
+    dataset.set_format("torch", columns=["input_ids", "attention_mask", "labels"])
+    return DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=True)
+
+
+def train_loop(model, optimizer, scheduler, train_loader, device, num_steps):
+    model.train()
+    data_iter = iter(train_loader)
+    losses = []
+
+    for step in range(num_steps):
+        try:
+            batch = next(data_iter)
+        except StopIteration:
+            data_iter = iter(train_loader)
+            batch = next(data_iter)
+
+        input_ids = batch["input_ids"].to(device)
+        labels = batch["labels"].to(device)
+
+        logits = model(input_ids[:, :-1])
+        loss = F.cross_entropy(logits.reshape(-1, logits.size(-1)), labels[:, 1:].reshape(-1))
+
+        optimizer.zero_grad()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+        optimizer.step()
+        scheduler.step()
+        losses.append(loss.item())
+
+        if step % 5 == 0:
+            print(f"  step {step:3d}  loss={loss.item():.4f}  lr={scheduler.get_last_lr()[0]:.2e}")
+
+    return losses
+
+
+def run_checkpoint_restore_test(
+    num_train_steps: int = 20,
+    num_continue_steps: int = 10,
+    batch_size: int = 4,
+    max_length: int = 128,
+):
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
+
+    print(f"Device: {device}")
+
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    tokenizer.pad_token = tokenizer.eos_token
+    vocab_size = len(tokenizer)
+
+    config = SmallGPTConfig(vocab_size=vocab_size, max_seq_len=max_length)
+    model = SmallGPT(config).to(device)
+    param_count = sum(p.numel() for p in model.parameters())
+    print(f"Model params: {param_count:,}")
+
+    train_loader = load_wikitext2(tokenizer, max_length=max_length, batch_size=batch_size)
+
+    total_steps = num_train_steps + num_continue_steps
+    optimizer = torch.optim.AdamW(model.parameters(), lr=3e-4, betas=(0.9, 0.95), weight_decay=0.01)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=total_steps)
+
+    # ========== Phase 1: Train and save ==========
+    print(f"\n{'=' * 60}")
+    print(f"Phase 1: Training for {num_train_steps} steps")
+    print(f"{'=' * 60}")
+
+    train_loop(model, optimizer, scheduler, train_loader, device, num_train_steps)
+
+    lr_before_save = scheduler.get_last_lr()[0]
+    sched_epoch_before = scheduler.state_dict()["last_epoch"]
+
+    checkpoint_dir = tempfile.mkdtemp(prefix="ckpt_restore_test_")
+    ckpt_path = f"{checkpoint_dir}/checkpoint.pt"
+    torch.save(
+        {
+            "model": model.state_dict(),
+            "optimizer": optimizer.state_dict(),
+            "scheduler": scheduler.state_dict(),
+            "global_step": num_train_steps,
+        },
+        ckpt_path,
+    )
+    print(f"\nCheckpoint saved to {ckpt_path}")
+    print(f"  LR at save: {lr_before_save:.2e}")
+    print(f"  Scheduler last_epoch: {sched_epoch_before}")
+
+    # ========== Phase 2: Fresh model + load + verify ==========
+    print(f"\n{'=' * 60}")
+    print(f"Phase 2: Loading checkpoint into fresh model")
+    print(f"{'=' * 60}")
+
+    model2 = SmallGPT(config).to(device)
+    optimizer2 = torch.optim.AdamW(model2.parameters(), lr=3e-4, betas=(0.9, 0.95), weight_decay=0.01)
+    scheduler2 = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer2, T_max=total_steps)
+
+    ckpt = torch.load(ckpt_path, map_location=device, weights_only=False)
+    model2.load_state_dict(ckpt["model"])
+    optimizer2.load_state_dict(ckpt["optimizer"])
+    scheduler2.load_state_dict(ckpt["scheduler"])
+
+    result = verify_optimizer_scheduler_restored(
+        optimizer2, scheduler2, expected_global_step=ckpt["global_step"]
+    )
+    print(f"\nverify_optimizer_scheduler_restored result:")
+    print(f"  restored_count: {result['restored_count']}/{result['total_count']}")
+    print(f"  current_lr:     {result['current_lr']:.2e}")
+    print(f"  last_epoch:     {result['last_epoch']}")
+
+    lr_after_load = scheduler2.get_last_lr()[0]
+    assert lr_after_load == lr_before_save, (
+        f"LR mismatch after restore: {lr_after_load} != {lr_before_save}"
+    )
+    assert result["restored_count"] == result["total_count"], (
+        f"Not all params restored: {result['restored_count']}/{result['total_count']}"
+    )
+    assert result["last_epoch"] == num_train_steps, (
+        f"Scheduler epoch mismatch: {result['last_epoch']} != {num_train_steps}"
+    )
+    print("All assertions passed.")
+
+    # ========== Phase 3: Continue training ==========
+    print(f"\n{'=' * 60}")
+    print(f"Phase 3: Continuing training for {num_continue_steps} steps")
+    print(f"{'=' * 60}")
+
+    train_loop(model2, optimizer2, scheduler2, train_loader, device, num_continue_steps)
+
+    lr_final = scheduler2.get_last_lr()[0]
+    epoch_final = scheduler2.state_dict()["last_epoch"]
+    assert epoch_final == num_train_steps + num_continue_steps, (
+        f"Scheduler epoch after continue: {epoch_final} != {num_train_steps + num_continue_steps}"
+    )
+
+    print(f"\n{'=' * 60}")
+    print(f"PASSED: Optimizer & scheduler restore verified end-to-end")
+    print(f"  Final LR: {lr_final:.2e}")
+    print(f"  Final scheduler epoch: {epoch_final}")
+    print(f"{'=' * 60}")
+
+
+if __name__ == "__main__":
+    run_checkpoint_restore_test()

--- a/llm/tests/test_checkpoint_restore.py
+++ b/llm/tests/test_checkpoint_restore.py
@@ -1,0 +1,230 @@
+"""
+Round-trip test for optimizer & scheduler state checkpoint restore.
+
+Verifies that after save → load, Adam momentum (exp_avg) and variance
+(exp_avg_sq) buffers and the LR scheduler state are preserved exactly.
+
+Requires: CUDA GPU + DeepSpeed.  Skipped automatically when unavailable.
+Run with:  deepspeed --num_gpus=1 -m pytest tests/test_checkpoint_restore.py -v
+"""
+
+import os
+import shutil
+import tempfile
+
+import pytest
+import torch
+import torch.nn as nn
+
+_CUDA = torch.cuda.is_available()
+
+try:
+    import deepspeed
+
+    _HAS_DS = True
+except ImportError:
+    _HAS_DS = False
+
+skip_no_cuda_ds = pytest.mark.skipif(
+    not (_CUDA and _HAS_DS),
+    reason="requires CUDA GPU and deepspeed",
+)
+
+
+# -- tiny model for testing ------------------------------------------------
+
+class TinyModel(nn.Module):
+    def __init__(self, d: int = 32):
+        super().__init__()
+        self.fc1 = nn.Linear(d, d)
+        self.fc2 = nn.Linear(d, d)
+
+    def forward(self, x):
+        return self.fc2(torch.relu(self.fc1(x)))
+
+
+# -- deepspeed config matching zero-0.yaml pattern -------------------------
+
+def _ds_config(total_steps: int = 100) -> dict:
+    return {
+        "train_batch_size": 1,
+        "train_micro_batch_size_per_gpu": 1,
+        "gradient_accumulation_steps": 1,
+        "optimizer": {
+            "type": "AdamW",
+            "params": {
+                "lr": 3e-4,
+                "betas": [0.9, 0.95],
+                "eps": 1e-10,
+                "weight_decay": 0,
+            },
+        },
+        "scheduler": {
+            "type": "WarmupCosineLR",
+            "params": {
+                "total_num_steps": total_steps,
+                "warmup_min_ratio": 0,
+                "warmup_num_steps": 10,
+                "cos_min_ratio": 0.1,
+                "warmup_type": "linear",
+            },
+        },
+        "zero_optimization": {"stage": 0},
+        "bf16": {"enabled": True},
+        "gradient_clipping": 1.0,
+    }
+
+
+def _init_engine(model, ds_config):
+    engine, _, _, _ = deepspeed.initialize(
+        config_params=ds_config,
+        model=model,
+        model_parameters=model.parameters(),
+    )
+    return engine
+
+
+def _train_steps(engine, n_steps: int = 5, d: int = 32):
+    """Run n forward/backward/step iterations to populate optimizer state."""
+    for _ in range(n_steps):
+        x = torch.randn(1, d, device=engine.device)
+        target = torch.randn(1, d, device=engine.device)
+        out = engine(x)
+        loss = ((out - target) ** 2).mean()
+        engine.backward(loss)
+        engine.step()
+
+
+def _get_adam_state(engine):
+    """Extract raw Adam optimizer state (exp_avg, exp_avg_sq) tensors."""
+    raw_opt = getattr(engine.optimizer, "optimizer", engine.optimizer)
+    state_snapshot = {}
+    for pid, state in raw_opt.state.items():
+        state_snapshot[pid] = {
+            "exp_avg": state["exp_avg"].clone().cpu(),
+            "exp_avg_sq": state["exp_avg_sq"].clone().cpu(),
+            "step": state.get("step"),
+        }
+    return state_snapshot
+
+
+def _get_scheduler_state(engine):
+    """Extract LR scheduler state."""
+    sched = engine.lr_scheduler
+    state = {}
+    if hasattr(sched, "get_last_lr"):
+        state["last_lr"] = sched.get_last_lr()
+    if hasattr(sched, "state_dict"):
+        state["state_dict"] = sched.state_dict()
+    return state
+
+
+# -- tests -----------------------------------------------------------------
+
+
+@skip_no_cuda_ds
+class TestOptimizerSchedulerRestore:
+    """Verify optimizer momentum/variance and scheduler state survive save→load."""
+
+    def test_round_trip_optimizer_state(self, tmp_path):
+        """Adam exp_avg and exp_avg_sq must match exactly after load."""
+        ckpt_dir = str(tmp_path / "ckpts")
+        tag = "test_ckpt"
+        n_train_steps = 5
+
+        # --- Phase 1: train and save ---
+        model = TinyModel()
+        engine = _init_engine(model, _ds_config())
+        _train_steps(engine, n_steps=n_train_steps)
+
+        state_before = _get_adam_state(engine)
+        sched_before = _get_scheduler_state(engine)
+
+        engine.save_checkpoint(ckpt_dir, tag=tag, client_state={"step": n_train_steps})
+
+        # Destroy old engine
+        del engine
+        torch.cuda.empty_cache()
+
+        # --- Phase 2: fresh engine + load ---
+        model2 = TinyModel()
+        engine2 = _init_engine(model2, _ds_config())
+        _, client_state = engine2.load_checkpoint(ckpt_dir, tag=tag)
+
+        state_after = _get_adam_state(engine2)
+        sched_after = _get_scheduler_state(engine2)
+
+        # -- Assertions: optimizer state --
+        assert state_before.keys() == state_after.keys(), (
+            "Mismatched parameter IDs after restore"
+        )
+
+        for pid in state_before:
+            before = state_before[pid]
+            after = state_after[pid]
+
+            assert torch.equal(before["exp_avg"], after["exp_avg"]), (
+                f"exp_avg mismatch for param {pid}"
+            )
+            assert torch.equal(before["exp_avg_sq"], after["exp_avg_sq"]), (
+                f"exp_avg_sq mismatch for param {pid}"
+            )
+
+            # Momentum should be non-zero after training
+            assert before["exp_avg"].any(), (
+                f"exp_avg is all zeros for param {pid} — optimizer didn't update"
+            )
+            assert before["exp_avg_sq"].any(), (
+                f"exp_avg_sq is all zeros for param {pid} — optimizer didn't update"
+            )
+
+        # -- Assertions: scheduler state --
+        if "last_lr" in sched_before and "last_lr" in sched_after:
+            assert sched_before["last_lr"] == sched_after["last_lr"], (
+                f"LR mismatch: {sched_before['last_lr']} != {sched_after['last_lr']}"
+            )
+
+        # -- Assertions: client state --
+        assert client_state is not None
+        assert client_state["step"] == n_train_steps
+
+        del engine2
+        torch.cuda.empty_cache()
+
+    def test_continued_training_after_restore(self, tmp_path):
+        """Training should continue seamlessly after restore (no LR reset)."""
+        ckpt_dir = str(tmp_path / "ckpts")
+        tag = "test_ckpt"
+
+        # --- Phase 1: train and save ---
+        model = TinyModel()
+        engine = _init_engine(model, _ds_config(total_steps=200))
+        _train_steps(engine, n_steps=10)
+
+        lr_before_save = engine.lr_scheduler.get_last_lr()[0]
+
+        engine.save_checkpoint(ckpt_dir, tag=tag, client_state={"step": 10})
+        del engine
+        torch.cuda.empty_cache()
+
+        # --- Phase 2: load and continue ---
+        model2 = TinyModel()
+        engine2 = _init_engine(model2, _ds_config(total_steps=200))
+        engine2.load_checkpoint(ckpt_dir, tag=tag)
+
+        lr_after_load = engine2.lr_scheduler.get_last_lr()[0]
+
+        # LR should match — scheduler was restored, not reset
+        assert lr_after_load == pytest.approx(lr_before_save, rel=1e-6), (
+            f"LR reset after restore: {lr_after_load} != {lr_before_save}"
+        )
+
+        # Continue training — should not error and LR should advance
+        _train_steps(engine2, n_steps=5)
+        lr_after_more = engine2.lr_scheduler.get_last_lr()[0]
+
+        # LR should have changed (scheduler is advancing)
+        assert lr_after_more != lr_after_load or True  # warmup may still be flat
+
+        del engine2
+        torch.cuda.empty_cache()

--- a/llm/tests/test_checkpoint_restore.py
+++ b/llm/tests/test_checkpoint_restore.py
@@ -1,37 +1,21 @@
 """
-Round-trip test for optimizer & scheduler state checkpoint restore.
+Unit tests for verify_optimizer_scheduler_restored.
 
-Verifies that after save → load, Adam momentum (exp_avg) and variance
-(exp_avg_sq) buffers and the LR scheduler state are preserved exactly.
+Tests the actual production function from llm.utils with controlled inputs.
+No GPU or DeepSpeed required.
 
-Requires: CUDA GPU + DeepSpeed.  Skipped automatically when unavailable.
-Run with:  deepspeed --num_gpus=1 -m pytest tests/test_checkpoint_restore.py -v
+Usage:
+    cd llm
+    uv run python -m pytest tests/test_checkpoint_restore.py -v
 """
-
-import os
-import shutil
-import tempfile
 
 import pytest
 import torch
 import torch.nn as nn
+import torch.optim as optim
 
-_CUDA = torch.cuda.is_available()
+from llm.utils import verify_optimizer_scheduler_restored
 
-try:
-    import deepspeed
-
-    _HAS_DS = True
-except ImportError:
-    _HAS_DS = False
-
-skip_no_cuda_ds = pytest.mark.skipif(
-    not (_CUDA and _HAS_DS),
-    reason="requires CUDA GPU and deepspeed",
-)
-
-
-# -- tiny model for testing ------------------------------------------------
 
 class TinyModel(nn.Module):
     def __init__(self, d: int = 32):
@@ -43,188 +27,135 @@ class TinyModel(nn.Module):
         return self.fc2(torch.relu(self.fc1(x)))
 
 
-# -- deepspeed config matching zero-0.yaml pattern -------------------------
-
-def _ds_config(total_steps: int = 100) -> dict:
-    return {
-        "train_batch_size": 1,
-        "train_micro_batch_size_per_gpu": 1,
-        "gradient_accumulation_steps": 1,
-        "optimizer": {
-            "type": "AdamW",
-            "params": {
-                "lr": 3e-4,
-                "betas": [0.9, 0.95],
-                "eps": 1e-10,
-                "weight_decay": 0,
-            },
-        },
-        "scheduler": {
-            "type": "WarmupCosineLR",
-            "params": {
-                "total_num_steps": total_steps,
-                "warmup_min_ratio": 0,
-                "warmup_num_steps": 10,
-                "cos_min_ratio": 0.1,
-                "warmup_type": "linear",
-            },
-        },
-        "zero_optimization": {"stage": 0},
-        "bf16": {"enabled": True},
-        "gradient_clipping": 1.0,
-    }
-
-
-def _init_engine(model, ds_config):
-    engine, _, _, _ = deepspeed.initialize(
-        config_params=ds_config,
-        model=model,
-        model_parameters=model.parameters(),
-    )
-    return engine
-
-
-def _train_steps(engine, n_steps: int = 5, d: int = 32):
-    """Run n forward/backward/step iterations to populate optimizer state."""
+def _train_steps(model, optimizer, scheduler, n_steps: int = 5, d: int = 32):
     for _ in range(n_steps):
-        x = torch.randn(1, d, device=engine.device)
-        target = torch.randn(1, d, device=engine.device)
-        out = engine(x)
-        loss = ((out - target) ** 2).mean()
-        engine.backward(loss)
-        engine.step()
+        x = torch.randn(1, d)
+        target = torch.randn(1, d)
+        loss = ((model(x) - target) ** 2).mean()
+        loss.backward()
+        optimizer.step()
+        scheduler.step()
+        optimizer.zero_grad()
 
 
-def _get_adam_state(engine):
-    """Extract raw Adam optimizer state (exp_avg, exp_avg_sq) tensors."""
-    raw_opt = getattr(engine.optimizer, "optimizer", engine.optimizer)
-    state_snapshot = {}
-    for pid, state in raw_opt.state.items():
-        state_snapshot[pid] = {
-            "exp_avg": state["exp_avg"].clone().cpu(),
-            "exp_avg_sq": state["exp_avg_sq"].clone().cpu(),
-            "step": state.get("step"),
-        }
-    return state_snapshot
+class TestVerifyOptimizerSchedulerRestored:
+    """Tests for the production verify_optimizer_scheduler_restored function."""
 
+    def test_passes_after_round_trip(self, tmp_path):
+        """Function passes when optimizer/scheduler state survives save → load."""
+        ckpt_path = str(tmp_path / "ckpt.pt")
 
-def _get_scheduler_state(engine):
-    """Extract LR scheduler state."""
-    sched = engine.lr_scheduler
-    state = {}
-    if hasattr(sched, "get_last_lr"):
-        state["last_lr"] = sched.get_last_lr()
-    if hasattr(sched, "state_dict"):
-        state["state_dict"] = sched.state_dict()
-    return state
-
-
-# -- tests -----------------------------------------------------------------
-
-
-@skip_no_cuda_ds
-class TestOptimizerSchedulerRestore:
-    """Verify optimizer momentum/variance and scheduler state survive save→load."""
-
-    def test_round_trip_optimizer_state(self, tmp_path):
-        """Adam exp_avg and exp_avg_sq must match exactly after load."""
-        ckpt_dir = str(tmp_path / "ckpts")
-        tag = "test_ckpt"
-        n_train_steps = 5
-
-        # --- Phase 1: train and save ---
         model = TinyModel()
-        engine = _init_engine(model, _ds_config())
-        _train_steps(engine, n_steps=n_train_steps)
+        optimizer = optim.AdamW(model.parameters(), lr=3e-4, betas=(0.9, 0.95))
+        scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=100)
+        _train_steps(model, optimizer, scheduler, n_steps=5)
 
-        state_before = _get_adam_state(engine)
-        sched_before = _get_scheduler_state(engine)
-
-        engine.save_checkpoint(ckpt_dir, tag=tag, client_state={"step": n_train_steps})
-
-        # Destroy old engine
-        del engine
-        torch.cuda.empty_cache()
-
-        # --- Phase 2: fresh engine + load ---
-        model2 = TinyModel()
-        engine2 = _init_engine(model2, _ds_config())
-        _, client_state = engine2.load_checkpoint(ckpt_dir, tag=tag)
-
-        state_after = _get_adam_state(engine2)
-        sched_after = _get_scheduler_state(engine2)
-
-        # -- Assertions: optimizer state --
-        assert state_before.keys() == state_after.keys(), (
-            "Mismatched parameter IDs after restore"
+        torch.save(
+            {
+                "model": model.state_dict(),
+                "optimizer": optimizer.state_dict(),
+                "scheduler": scheduler.state_dict(),
+            },
+            ckpt_path,
         )
 
-        for pid in state_before:
-            before = state_before[pid]
-            after = state_after[pid]
-
-            assert torch.equal(before["exp_avg"], after["exp_avg"]), (
-                f"exp_avg mismatch for param {pid}"
-            )
-            assert torch.equal(before["exp_avg_sq"], after["exp_avg_sq"]), (
-                f"exp_avg_sq mismatch for param {pid}"
-            )
-
-            # Momentum should be non-zero after training
-            assert before["exp_avg"].any(), (
-                f"exp_avg is all zeros for param {pid} — optimizer didn't update"
-            )
-            assert before["exp_avg_sq"].any(), (
-                f"exp_avg_sq is all zeros for param {pid} — optimizer didn't update"
-            )
-
-        # -- Assertions: scheduler state --
-        if "last_lr" in sched_before and "last_lr" in sched_after:
-            assert sched_before["last_lr"] == sched_after["last_lr"], (
-                f"LR mismatch: {sched_before['last_lr']} != {sched_after['last_lr']}"
-            )
-
-        # -- Assertions: client state --
-        assert client_state is not None
-        assert client_state["step"] == n_train_steps
-
-        del engine2
-        torch.cuda.empty_cache()
-
-    def test_continued_training_after_restore(self, tmp_path):
-        """Training should continue seamlessly after restore (no LR reset)."""
-        ckpt_dir = str(tmp_path / "ckpts")
-        tag = "test_ckpt"
-
-        # --- Phase 1: train and save ---
-        model = TinyModel()
-        engine = _init_engine(model, _ds_config(total_steps=200))
-        _train_steps(engine, n_steps=10)
-
-        lr_before_save = engine.lr_scheduler.get_last_lr()[0]
-
-        engine.save_checkpoint(ckpt_dir, tag=tag, client_state={"step": 10})
-        del engine
-        torch.cuda.empty_cache()
-
-        # --- Phase 2: load and continue ---
         model2 = TinyModel()
-        engine2 = _init_engine(model2, _ds_config(total_steps=200))
-        engine2.load_checkpoint(ckpt_dir, tag=tag)
+        optimizer2 = optim.AdamW(model2.parameters(), lr=3e-4, betas=(0.9, 0.95))
+        scheduler2 = optim.lr_scheduler.CosineAnnealingLR(optimizer2, T_max=100)
 
-        lr_after_load = engine2.lr_scheduler.get_last_lr()[0]
+        ckpt = torch.load(ckpt_path, weights_only=False)
+        model2.load_state_dict(ckpt["model"])
+        optimizer2.load_state_dict(ckpt["optimizer"])
+        scheduler2.load_state_dict(ckpt["scheduler"])
 
-        # LR should match — scheduler was restored, not reset
-        assert lr_after_load == pytest.approx(lr_before_save, rel=1e-6), (
-            f"LR reset after restore: {lr_after_load} != {lr_before_save}"
+        result = verify_optimizer_scheduler_restored(optimizer2, scheduler2, expected_global_step=5)
+
+        assert result["restored_count"] == result["total_count"]
+        assert result["restored_count"] > 0
+        assert result["last_epoch"] == 5
+        assert result["current_lr"] is not None
+
+    def test_raises_on_empty_state(self):
+        """Raises RuntimeError when optimizer has no state at all."""
+        model = TinyModel()
+        optimizer = optim.AdamW(model.parameters(), lr=3e-4)
+        scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=100)
+
+        with pytest.raises(RuntimeError, match="Optimizer state is empty"):
+            verify_optimizer_scheduler_restored(optimizer, scheduler, expected_global_step=10)
+
+    def test_raises_on_zero_buffers_after_step_2(self):
+        """Raises when all momentum/variance buffers are zeros at step > 2."""
+        model = TinyModel()
+        optimizer = optim.AdamW(model.parameters(), lr=3e-4)
+        scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=100)
+
+        for param in model.parameters():
+            optimizer.state[param] = {
+                "exp_avg": torch.zeros_like(param),
+                "exp_avg_sq": torch.zeros_like(param),
+                "step": torch.tensor(10.0),
+            }
+
+        with pytest.raises(RuntimeError, match="non-zero momentum/variance"):
+            verify_optimizer_scheduler_restored(optimizer, scheduler, expected_global_step=10)
+
+    def test_tolerates_zero_buffers_at_early_steps(self):
+        """At global_step <= 2, all-zero buffers should NOT raise."""
+        model = TinyModel()
+        optimizer = optim.AdamW(model.parameters(), lr=3e-4)
+        scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=100)
+
+        for param in model.parameters():
+            optimizer.state[param] = {
+                "exp_avg": torch.zeros_like(param),
+                "exp_avg_sq": torch.zeros_like(param),
+                "step": torch.tensor(1.0),
+            }
+
+        result = verify_optimizer_scheduler_restored(optimizer, scheduler, expected_global_step=1)
+        assert result["restored_count"] == 0
+        assert result["total_count"] > 0
+
+    def test_lr_preserved_after_restore(self, tmp_path):
+        """LR should not reset to initial value after restore."""
+        ckpt_path = str(tmp_path / "ckpt.pt")
+
+        model = TinyModel()
+        optimizer = optim.AdamW(model.parameters(), lr=3e-4, betas=(0.9, 0.95))
+        scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=200)
+        _train_steps(model, optimizer, scheduler, n_steps=20)
+
+        lr_at_save = scheduler.get_last_lr()[0]
+
+        torch.save({"optimizer": optimizer.state_dict(), "scheduler": scheduler.state_dict()}, ckpt_path)
+
+        model2 = TinyModel()
+        optimizer2 = optim.AdamW(model2.parameters(), lr=3e-4, betas=(0.9, 0.95))
+        scheduler2 = optim.lr_scheduler.CosineAnnealingLR(optimizer2, T_max=200)
+
+        ckpt = torch.load(ckpt_path, weights_only=False)
+        optimizer2.load_state_dict(ckpt["optimizer"])
+        scheduler2.load_state_dict(ckpt["scheduler"])
+
+        result = verify_optimizer_scheduler_restored(optimizer2, scheduler2, expected_global_step=20)
+
+        assert result["current_lr"] == pytest.approx(lr_at_save, rel=1e-6)
+        assert result["last_epoch"] == 20
+
+    def test_scheduler_none_accepted(self):
+        """Function works when lr_scheduler is None."""
+        model = TinyModel()
+        optimizer = optim.AdamW(model.parameters(), lr=3e-4)
+        _train_steps(
+            model,
+            optimizer,
+            optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=100),
+            n_steps=5,
         )
 
-        # Continue training — should not error and LR should advance
-        _train_steps(engine2, n_steps=5)
-        lr_after_more = engine2.lr_scheduler.get_last_lr()[0]
+        result = verify_optimizer_scheduler_restored(optimizer, None, expected_global_step=5)
 
-        # LR should have changed (scheduler is advancing)
-        assert lr_after_more != lr_after_load or True  # warmup may still be flat
-
-        del engine2
-        torch.cuda.empty_cache()
+        assert result["restored_count"] > 0
+        assert result["current_lr"] is None
+        assert result["last_epoch"] is None


### PR DESCRIPTION
# Pull Request Template

## Description

Task: Optimizer state restored correctly (momentum, variance).

When training is paused and resumed from a checkpoint, DeepSpeed's load_checkpoint restores optimizer and scheduler states automatically. However, there was no verification that this restore actually succeeded — a silent failure (empty buffers, reset LR) would cause training to diverge without any warning.

This PR adds:

verify_optimizer_scheduler_restored() in llm/src/llm/utils.py — a standalone, testable function that checks:

- Optimizer state is not empty after restore
- Adam exp_avg (momentum) and exp_avg_sq (variance) buffers are non-zero (with a guard for early-step checkpoints at step <= 2)
- Scheduler last_epoch and current LR are consistent with the restored global step
- PreTrainer integration in llm/src/llm/pretrainer.py — calls the verification function in _resume() after checkpoint load, logs a - summary on rank 0, and prints a warning if scheduler state appears unrestore.

Unit tests in llm/tests/test_checkpoint_restore.py — 6 tests exercising the actual production function:

- Round-trip save → load passes verification
- Raises on empty optimizer state
- Raises on all-zero momentum/variance buffers (step > 2)
- Tolerates zero buffers at early steps (step <= 2)
- LR preserved after restore
- Accepts None scheduler
- Integration test in llm/tests/local_checkpoint_restore_test.py — trains a ~28M param SmallGPT on wikitext-2 (HuggingFace), saves a checkpoint, loads into a fresh model, calls the production verification function, then continues training. Runs on CPU/MPS/CUDA without DeepSpeed.

Key files changed
- llm/src/llm/utils.py — new verify_optimizer_scheduler_restored() function
- llm/src/llm/pretrainer.py — _resume() now calls verification, new _verify_optimizer_scheduler_restored() method delegates to utils
- llm/tests/test_checkpoint_restore.py — unit tests (new file)
- llm/tests/local_checkpoint_restore_test.py — integration test (new file)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [ ] My code follows the style guidelines, gitflow branching strategy, and naming conventions of this project [Contribution Guidelines](<https://github.com/The-School-of-AI/LLM/tree/main/experiments/>
