### PR TITLE
Resume recovery - RNG state manager

### DIFF
--- a/llm/src/llm/pretrainer.py
+++ b/llm/src/llm/pretrainer.py
@@ -11,6 +11,7 @@ from llm.config import Config
 from llm.kernels import HAS_TRITON, FusedLinearCrossEntropyLoss
 from llm.logger import Metrics
 from llm.profiler import PipelineProfiler
+from llm.rng_state_manager import RNGStateManager
 from llm.utils import is_main_process
 
 
@@ -172,6 +173,10 @@ class PreTrainer:
         )
 
         if client_state:
+            rng_state = client_state.get("rng_state")
+            if rng_state:
+                RNGStateManager.restore(rng_state)
+
             start_epoch = client_state.get("epoch", 0)
             global_step = client_state.get("global_step", 0)
             start_step = client_state.get("step", 0)
@@ -410,6 +415,7 @@ class PreTrainer:
                 "epoch": epoch,
                 "step": step,
                 "global_step": global_step,
+                "rng_state": RNGStateManager.capture(),
             }
             | kwargs,
         )

--- a/llm/src/llm/rng_state_manager.py
+++ b/llm/src/llm/rng_state_manager.py
@@ -1,0 +1,67 @@
+"""RNG state manager for reproducible training resume.
+
+Captures and restores random number generator states across all libraries
+(Python, NumPy, PyTorch CPU, PyTorch CUDA) so that training after resume
+behaves as if the interruption never happened.
+"""
+
+import random
+import warnings
+from typing import Any
+
+import numpy as np
+import torch
+
+
+class RNGStateManager:
+    """Captures and restores RNG states for reproducible training resume."""
+
+    @staticmethod
+    def capture() -> dict[str, Any]:
+        """Capture all RNG states.
+
+        Returns:
+            Dict with keys: python, numpy, torch_cpu, torch_cuda.
+        """
+        state: dict[str, Any] = {
+            "python": random.getstate(),
+            "numpy": np.random.get_state(),
+            "torch_cpu": torch.random.get_rng_state(),
+            "torch_cuda": (
+                torch.cuda.get_rng_state_all()
+                if torch.cuda.is_available()
+                else []
+            ),
+        }
+        return state
+
+    @staticmethod
+    def restore(rng_state: dict[str, Any]) -> None:
+        """Restore all RNG states from a previously captured dict.
+
+        Args:
+            rng_state: Dict produced by :meth:`capture`.
+        """
+        if "python" in rng_state:
+            random.setstate(rng_state["python"])
+
+        if "numpy" in rng_state:
+            np.random.set_state(rng_state["numpy"])
+
+        if "torch_cpu" in rng_state:
+            torch.random.set_rng_state(rng_state["torch_cpu"])
+
+        if "torch_cuda" in rng_state and rng_state["torch_cuda"]:
+            if torch.cuda.is_available():
+                saved = rng_state["torch_cuda"]
+                current_device_count = torch.cuda.device_count()
+                if len(saved) == current_device_count:
+                    torch.cuda.set_rng_state_all(saved)
+                else:
+                    warnings.warn(
+                        f"CUDA RNG state not restored: checkpoint has {len(saved)} "
+                        f"device(s), current run has {current_device_count}. "
+                        f"Reproducibility not guaranteed.",
+                        UserWarning,
+                        stacklevel=2,
+                    )

--- a/llm/tests/test_rng_state_e2e.py
+++ b/llm/tests/test_rng_state_e2e.py
@@ -1,0 +1,164 @@
+"""End-to-end test: train a small LLM, checkpoint RNG state, resume, verify losses match.
+
+Strategy: both baseline and resume runs create a NEW DataLoader at the checkpoint
+boundary. This ensures the shuffle permutation for phase-2 is determined entirely
+by the RNG state at that moment — which is exactly what RNGStateManager restores.
+"""
+
+import copy
+import random
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llm.rng_state_manager import RNGStateManager
+
+TOTAL_STEPS = 10
+CHECKPOINT_STEP = 5
+SEED = 42
+BATCH_SIZE = 4
+SEQ_LEN = 64
+
+
+def _set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+
+def _prepare_dataset(tokenizer, num_samples: int = 50) -> TensorDataset:
+    """Load wikitext-2-raw-v1 and tokenize into a small TensorDataset."""
+    from datasets import load_dataset
+
+    ds = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
+    texts = [t for t in ds["text"] if t.strip()][:num_samples]
+    full_text = " ".join(texts)
+
+    tokens = tokenizer(
+        full_text,
+        return_tensors="pt",
+        truncation=False,
+    )["input_ids"].squeeze(0)
+
+    n_chunks = len(tokens) // SEQ_LEN
+    tokens = tokens[: n_chunks * SEQ_LEN].reshape(n_chunks, SEQ_LEN)
+    return TensorDataset(tokens)
+
+
+def _train_steps(
+    model: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    loader: DataLoader,
+    num_steps: int,
+) -> list[float]:
+    """Train for num_steps and return the loss at each step."""
+    model.train()
+    losses = []
+    step = 0
+    while step < num_steps:
+        for (batch,) in loader:
+            if step >= num_steps:
+                break
+            labels = batch.clone()
+            out = model(input_ids=batch, labels=labels)
+            loss = out.loss
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+            losses.append(loss.item())
+            step += 1
+    return losses
+
+
+def _run_two_phase_training(
+    dataset: TensorDataset,
+    trash_and_restore: bool,
+) -> list[float]:
+    """Run training in two phases with a checkpoint boundary between them.
+
+    Phase 1: seed → train CHECKPOINT_STEP steps
+    Checkpoint: capture RNG + model + optimizer state
+    Phase 2: (optionally trash & restore RNG) → new DataLoader → train remaining steps
+
+    Both baseline (trash_and_restore=False) and resume (trash_and_restore=True)
+    create a fresh DataLoader at the checkpoint boundary, so the phase-2 shuffle
+    order depends entirely on the RNG state — which is what we're testing.
+    """
+    _set_seed(SEED)
+    model = AutoModelForCausalLM.from_pretrained("sshleifer/tiny-gpt2")
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+
+    # --- Phase 1 ---
+    loader1 = DataLoader(dataset, batch_size=BATCH_SIZE, shuffle=True, drop_last=True)
+    _train_steps(model, optimizer, loader1, CHECKPOINT_STEP)
+
+    # --- Checkpoint boundary ---
+    rng_snapshot = RNGStateManager.capture()
+    model_snapshot = copy.deepcopy(model.state_dict())
+    opt_snapshot = copy.deepcopy(optimizer.state_dict())
+
+    if trash_and_restore:
+        # Simulate process restart: destroy all RNG state
+        _set_seed(999)
+        _ = [random.random() for _ in range(100)]
+        _ = np.random.rand(100)
+        _ = torch.randn(100)
+
+        # Restore from "checkpoint"
+        RNGStateManager.restore(rng_snapshot)
+        model.load_state_dict(model_snapshot)
+        optimizer.load_state_dict(opt_snapshot)
+
+    # --- Phase 2: new DataLoader (shuffle order determined by current RNG) ---
+    loader2 = DataLoader(dataset, batch_size=BATCH_SIZE, shuffle=True, drop_last=True)
+    phase2_losses = _train_steps(model, optimizer, loader2, TOTAL_STEPS - CHECKPOINT_STEP)
+    return phase2_losses
+
+
+class TestRNGStateE2E:
+    """Prove that RNG capture/restore produces identical training after resume."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _setup(self, request):
+        """Load tokenizer and dataset once for all tests in this class."""
+        tokenizer = AutoTokenizer.from_pretrained("sshleifer/tiny-gpt2")
+        tokenizer.pad_token = tokenizer.eos_token
+        request.cls.dataset = _prepare_dataset(tokenizer)
+
+    def test_resumed_training_matches_baseline(self):
+        """Phase-2 losses must be identical whether or not RNG was trashed and restored."""
+        baseline_losses = _run_two_phase_training(self.dataset, trash_and_restore=False)
+        resumed_losses = _run_two_phase_training(self.dataset, trash_and_restore=True)
+
+        assert len(baseline_losses) == len(resumed_losses)
+        for i, (bl, rl) in enumerate(zip(baseline_losses, resumed_losses)):
+            assert bl == pytest.approx(rl, abs=1e-6), (
+                f"Step {CHECKPOINT_STEP + i + 1}: baseline loss {bl} != resumed loss {rl}"
+            )
+
+    def test_without_rng_restore_losses_diverge(self):
+        """Without RNG restore, losses must differ (proving the restore matters)."""
+        baseline_losses = _run_two_phase_training(self.dataset, trash_and_restore=False)
+
+        # Run with trashed RNG but NO restore
+        _set_seed(SEED)
+        model = AutoModelForCausalLM.from_pretrained("sshleifer/tiny-gpt2")
+        optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+
+        loader1 = DataLoader(self.dataset, batch_size=BATCH_SIZE, shuffle=True, drop_last=True)
+        _train_steps(model, optimizer, loader1, CHECKPOINT_STEP)
+
+        # Trash RNG without restoring
+        _set_seed(999)
+
+        loader2 = DataLoader(self.dataset, batch_size=BATCH_SIZE, shuffle=True, drop_last=True)
+        no_restore_losses = _train_steps(model, optimizer, loader2, TOTAL_STEPS - CHECKPOINT_STEP)
+
+        mismatches = sum(
+            1 for bl, nl in zip(baseline_losses, no_restore_losses) if abs(bl - nl) > 1e-6
+        )
+        assert mismatches > 0, "Expected losses to diverge without RNG restore"

--- a/llm/tests/test_rng_state_manager.py
+++ b/llm/tests/test_rng_state_manager.py
@@ -1,0 +1,142 @@
+"""Tests for RNGStateManager."""
+
+import random
+
+import numpy as np
+import pytest
+import torch
+
+from llm.rng_state_manager import RNGStateManager
+
+
+class TestCapture:
+    def test_returns_expected_keys(self):
+        state = RNGStateManager.capture()
+        assert "python" in state
+        assert "numpy" in state
+        assert "torch_cpu" in state
+        assert "torch_cuda" in state
+
+    def test_python_state_is_tuple(self):
+        state = RNGStateManager.capture()
+        assert isinstance(state["python"], tuple)
+
+    def test_numpy_state_is_dict(self):
+        state = RNGStateManager.capture()
+        # np.random.get_state returns a dict (numpy >= 1.17) or tuple
+        assert isinstance(state["numpy"], (dict, tuple))
+
+    def test_torch_cpu_state_is_tensor(self):
+        state = RNGStateManager.capture()
+        assert isinstance(state["torch_cpu"], torch.Tensor)
+
+    def test_torch_cuda_empty_when_no_gpu(self):
+        if torch.cuda.is_available():
+            pytest.skip("CUDA is available, cannot test no-GPU path")
+        state = RNGStateManager.capture()
+        assert state["torch_cuda"] == []
+
+
+class TestRoundTrip:
+    def test_python_rng_restored(self):
+        random.seed(42)
+        state = RNGStateManager.capture()
+
+        # Advance RNG
+        _ = [random.random() for _ in range(100)]
+
+        RNGStateManager.restore(state)
+        # Should produce same sequence as right after seed(42)
+        random.seed(42)
+        expected = [random.random() for _ in range(5)]
+
+        RNGStateManager.restore(state)
+        actual = [random.random() for _ in range(5)]
+        assert actual == expected
+
+    def test_numpy_rng_restored(self):
+        np.random.seed(42)
+        state = RNGStateManager.capture()
+
+        # Advance RNG
+        _ = np.random.rand(100)
+
+        RNGStateManager.restore(state)
+        actual = np.random.rand(5)
+
+        # Restore again to get expected
+        RNGStateManager.restore(state)
+        expected = np.random.rand(5)
+
+        np.testing.assert_array_equal(actual, expected)
+
+    def test_torch_cpu_rng_restored(self):
+        torch.manual_seed(42)
+        state = RNGStateManager.capture()
+
+        # Advance RNG
+        _ = torch.randn(100)
+
+        RNGStateManager.restore(state)
+        actual = torch.randn(5)
+
+        RNGStateManager.restore(state)
+        expected = torch.randn(5)
+
+        assert torch.equal(actual, expected)
+
+    def test_full_round_trip(self):
+        """Capture all states, advance all RNGs, restore, verify all match."""
+        random.seed(99)
+        np.random.seed(99)
+        torch.manual_seed(99)
+
+        state = RNGStateManager.capture()
+
+        # Advance all RNGs
+        _ = random.random()
+        _ = np.random.rand()
+        _ = torch.randn(1)
+
+        # Restore
+        RNGStateManager.restore(state)
+
+        # Generate "after restore" values
+        py_val = random.random()
+        np_val = np.random.rand()
+        torch_val = torch.randn(1)
+
+        # Restore again and compare
+        RNGStateManager.restore(state)
+        assert random.random() == py_val
+        np.testing.assert_equal(np.random.rand(), np_val)
+        assert torch.equal(torch.randn(1), torch_val)
+
+
+class TestPartialRestore:
+    def test_missing_keys_does_not_raise(self):
+        """Restore with partial dict should not error."""
+        RNGStateManager.restore({})
+        RNGStateManager.restore({"python": random.getstate()})
+
+    def test_empty_cuda_list_does_not_raise(self):
+        RNGStateManager.restore({"torch_cuda": []})
+
+
+class TestCheckpointIntegration:
+    def test_state_can_be_merged_into_client_state(self):
+        """RNG state dict should be serializable alongside checkpoint metadata."""
+        rng_state = RNGStateManager.capture()
+        client_state = {
+            "epoch": 1,
+            "step": 100,
+            "global_step": 500,
+            "rng_state": rng_state,
+        }
+        assert "rng_state" in client_state
+        assert set(client_state["rng_state"].keys()) == {
+            "python",
+            "numpy",
+            "torch_cpu",
+            "torch_cuda",
+        }


### PR DESCRIPTION
# Pull Request Template

## Description

RNG State Restoration for Reproducible Training Resume

When training resumes from a checkpoint, random number generator states were not being saved or restored. This caused data shuffling order, dropout masks, and other random operations to diverge from the original run, making training non-reproducible after resume.

This PR adds an RNGStateManager module that captures and restores RNG states across all libraries (Python random, NumPy, PyTorch CPU, PyTorch CUDA) and integrates it into the checkpoint save/load pipeline with minimal changes to existing code.

What changed

New files:

- llm/src/llm/rng_state_manager.py — RNGStateManager class with capture() and restore() static methods. Handles all 4 RNG sources, guards against CUDA device count mismatch on world-size changes (warns instead of crashing), and gracefully skips CUDA RNG when no GPU is available.
- llm/tests/test_rng_state_manager.py — 12 unit tests covering capture key structure, round-trip restore for all RNG sources, partial/empty state handling, and checkpoint dict integration.
- llm/tests/test_rng_state_e2e.py — 2 end-to-end tests that train sshleifer/tiny-gpt2 on wikitext-2-raw-v1, checkpoint RNG state mid-training, trash and restore it, then verify losses match the uninterrupted baseline exactly. Includes a negative test proving losses diverge without restore.

Modified files:

- llm/src/llm/pretrainer.py — 2 minimal changes:
- _save_checkpoint(): adds "rng_state": RNGStateManager.capture() to client_state
- _resume(): calls RNGStateManager.restore(rng_state) before training resumes

Key design decisions

- Static methods, no instance state — drop-in single-call API
- RNG state stored inside existing client_state dict — no checkpoint format changes
- Per-rank by default since DeepSpeed saves client_state per-rank in each shard
- Restore happens in _resume() before training loop iterates, which is correct because both DistributedSampler and
- DataLoader(shuffle=True) consume RNG at iterator creation time, not at construction

